### PR TITLE
Use the instances key_properties instead of the constant

### DIFF
--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -75,10 +75,12 @@ class Stream():
 
         mdata = metadata.write(mdata, (), 'table-key-properties', self.key_properties)
         mdata = metadata.write(mdata, (), 'forced-replication-method', self.replication_method)
-        mdata = metadata.write(mdata, (), 'valid-replication-keys', [self.replication_key])
+
+        if self.replication_key:
+            mdata = metadata.write(mdata, (), 'valid-replication-keys', [self.replication_key])
 
         for field_name in schema['properties'].keys():
-            if field_name in KEY_PROPERTIES or field_name == self.replication_key:
+            if field_name in self.key_properties or field_name == self.replication_key:
                 mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
             else:
                 mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'available')


### PR DESCRIPTION
This refactor happened but wasn't working for Tags as it has a different set of key properties.

Also found that Tags (which uses FULL_TABLE replication) was writing an array of `[null]` which wasn't hurting but looked silly.