### PR TITLE
Fix organization fields schema issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-zendesk',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_zendesk'],
       install_requires=[
-          'singer-python==5.1.0',
+          'singer-python==5.1.5',
           'zenpy==2.0.0',
       ],
       entry_points='''

--- a/tap_zendesk/schemas/organizations.json
+++ b/tap_zendesk/schemas/organizations.json
@@ -102,6 +102,13 @@
         "null",
         "integer"
       ]
+    },
+    "deleted_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
     }
   }
 }


### PR DESCRIPTION
Organization fields has a dynamic schema, when there are no custom fields, the "properties" is an empty object. Singer python recently received a fix to handle this case properly, so bumped it to 5.1.5 for that.

Also, added `deleted_at` to the organizations schema, since it was coming back in the API response.