### PR TITLE
Feature/request ticket audits per ticket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
             source ~/.virtualenvs/tap-zendesk/bin/activate
             pip install .
             pip install pylint
-            pylint tap_zendesk -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme,stop-iteration-return
+            pylint tap_zendesk -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme,stop-iteration-return,too-many-branches
       - run:
           name: 'Unit Tests'
           command: |

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -42,7 +42,7 @@ SUB_STREAMS = {
 
 def get_sub_stream_names():
     sub_stream_names = []
-    for parent_stream in SUB_STREAMS.keys():
+    for parent_stream in SUB_STREAMS:
         sub_stream_names.extend(SUB_STREAMS[parent_stream])
     return sub_stream_names
 
@@ -53,7 +53,7 @@ def validate_dependencies(selected_stream_ids):
     errs = []
     msg_tmpl = ("Unable to extract {0} data. "
                 "To receive {0} data, you also need to select {1}.")
-    for parent_stream_name in SUB_STREAMS.keys():
+    for parent_stream_name in SUB_STREAMS:
         sub_stream_names = SUB_STREAMS[parent_stream_name]
         for sub_stream_name in sub_stream_names:
             if sub_stream_name in selected_stream_ids and parent_stream_name not in selected_stream_ids:
@@ -110,7 +110,7 @@ def do_sync(client, catalog, state, start_date):
 
         LOGGER.info("%s: Starting sync", stream_name)
         instance = STREAMS[stream_name](client)
-        counter_value = sync_stream(client, state, start_date, instance)
+        counter_value = sync_stream(state, start_date, instance)
         LOGGER.info("%s: Completed sync (%s rows)", stream_name, counter_value)
 
     singer.write_state(state)

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -97,6 +97,8 @@ def do_sync(client, catalog, state, start_date):
         sub_stream_names = SUB_STREAMS.get(stream_name)
         if sub_stream_names:
             for sub_stream_name in sub_stream_names:
+                if sub_stream_name not in selected_stream_names:
+                    continue
                 sub_stream = STREAMS[sub_stream_name].stream
                 sub_mdata = metadata.to_map(sub_stream.metadata)
                 sub_key_properties = metadata.get(sub_mdata, (), 'table-key-properties')

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -37,7 +37,7 @@ def get_selected_streams(catalog):
 
 
 SUB_STREAMS = {
-    'tickets': ['ticket_audits']
+    'tickets': ['ticket_audits', 'ticket_metrics']
 }
 
 def get_sub_stream_names():

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 import json
 import sys
-import singer
 
-from singer import metadata
 from zenpy import Zenpy
 from tap_zendesk.discover import discover_streams
 from tap_zendesk.sync import sync_stream
 from tap_zendesk.streams import STREAMS
+
+import singer
+from singer import metadata
 
 LOGGER = singer.get_logger()
 

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python3
 import json
 import sys
-
+import singer
+from singer import metadata
 from zenpy import Zenpy
 from tap_zendesk.discover import discover_streams
 from tap_zendesk.sync import sync_stream
 from tap_zendesk.streams import STREAMS
-
-import singer
-from singer import metadata
 
 LOGGER = singer.get_logger()
 
@@ -95,6 +93,7 @@ def do_sync(client, catalog, state, start_date):
         singer.write_state(state)
         key_properties = metadata.get(mdata, (), 'table-key-properties')
         singer.write_schema(stream_name, stream.schema.to_dict(), key_properties)
+
         sub_stream_names = SUB_STREAMS.get(stream_name)
         if sub_stream_names:
             for sub_stream_name in sub_stream_names:

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -66,7 +66,7 @@ def populate_class_schemas(catalog, selected_stream_names):
     for stream in catalog.streams:
         if stream.tap_stream_id in selected_stream_names:
             STREAMS[stream.tap_stream_id].stream = stream
-    
+
 def do_sync(client, catalog, state, start_date):
 
     selected_stream_names = get_selected_streams(catalog)

--- a/tap_zendesk/schemas/ticket_audits.json
+++ b/tap_zendesk/schemas/ticket_audits.json
@@ -394,6 +394,12 @@
               "null",
               "boolean"
             ]
+          },
+          "resource": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       }

--- a/tap_zendesk/schemas/ticket_fields.json
+++ b/tap_zendesk/schemas/ticket_fields.json
@@ -177,6 +177,19 @@
         "null",
         "boolean"
       ]
+    },
+    "system_field_options": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {}
+    },
+    "sub_type_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
     }
   },
   "type": [

--- a/tap_zendesk/schemas/tickets.json
+++ b/tap_zendesk/schemas/tickets.json
@@ -377,6 +377,26 @@
           "integer"
         ]
       }
+    },
+    "problem_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "forum_topic_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "satisfaction_rating": {
+      "type": [
+        "null",
+        "object",
+        "string"
+      ],
+      "properties": {}
     }
   },
   "type": [

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -281,7 +281,7 @@ class Tags(Stream):
     def sync(self, state): # pylint: disable=unused-argument
         # NB: Setting page to force it to paginate all tags, instead of just the
         #     top 100 popular tags
-        return self.client.tags(page=1)
+        return (self.stream, self.client.tags(page=1))
 
 class TicketFields(Stream):
     name = "ticket_fields"

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -281,7 +281,9 @@ class Tags(Stream):
     def sync(self, state): # pylint: disable=unused-argument
         # NB: Setting page to force it to paginate all tags, instead of just the
         #     top 100 popular tags
-        return (self.stream, self.client.tags(page=1))
+        tags = self.client.tags(page=1)
+        for tag in tags:
+            yield (self.stream, tag)
 
 class TicketFields(Stream):
     name = "ticket_fields"

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -295,7 +295,6 @@ class TicketFields(Stream):
                 self.update_bookmark(state, field.updated_at)
                 yield (self.stream, field)
 
-
 class GroupMemberships(Stream):
     name = "group_memberships"
     replication_method = "INCREMENTAL"

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -48,6 +48,7 @@ class Stream():
     replication_method = None
     replication_key = None
     key_properties = KEY_PROPERTIES
+    stream = None
 
     def __init__(self, client=None):
         self.client = client
@@ -86,6 +87,9 @@ class Stream():
                 mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'available')
 
         return metadata.to_list(mdata)
+
+    def is_selected(self):
+        return self.stream is not None
 
 class Organizations(Stream):
     name = "organizations"
@@ -139,6 +143,7 @@ class Tickets(Stream):
     def sync(self, state):
         bookmark = self.get_bookmark(state)
         tickets = self.client.tickets.incremental(start_time=bookmark)
+        audits_stream = TicketAudits(self.client)
         for ticket in tickets:
             if utils.strptime_with_tz(ticket.updated_at) < bookmark:
                 # NB: Skip tickets that might show up because of Zendesk behavior:

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -113,7 +113,7 @@ class Organizations(Stream):
         organizations = self.client.organizations.incremental(start_time=bookmark)
         for organization in organizations:
             self.update_bookmark(state, organization.updated_at)
-            yield organization
+            yield (self.stream, organization)
 
 class Users(Stream):
     name = "users"
@@ -133,17 +133,21 @@ class Users(Stream):
         users = self.client.users.incremental(start_time=bookmark)
         for user in users:
             self.update_bookmark(state, user.updated_at)
-            yield user
+            yield (self.stream, user)
 
+# TODO: Make these track and log metrics themselves when yielding, much like singer.metrics
+# - Could use singer.metrics.log() manually to handle the interleaved streams
 class Tickets(Stream):
     name = "tickets"
     replication_method = "INCREMENTAL"
     replication_key = "updated_at"
-
+    
     def sync(self, state):
         bookmark = self.get_bookmark(state)
         tickets = self.client.tickets.incremental(start_time=bookmark)
         audits_stream = TicketAudits(self.client)
+        ticket_buffer = []
+        audit_buffer = []
         for ticket in tickets:
             if utils.strptime_with_tz(ticket.updated_at) < bookmark:
                 # NB: Skip tickets that might show up because of Zendesk behavior:
@@ -153,36 +157,43 @@ class Tickets(Stream):
             self.update_bookmark(state, ticket.updated_at)
             ticket_dict = ticket.to_dict()
             ticket_dict.pop('fields') # NB: Fields is a duplicate of custom_fields, remove before emitting
-            yield ticket_dict
+
+            ticket_buffer.append((self.stream, ticket_dict))
+            if len(ticket_buffer) >= 10:
+                for t in ticket_buffer:
+                    yield t
+                ticket_buffer = []
 
             if audits_stream.is_selected():
                 for audit in audits_stream.sync(ticket_dict["id"]):
-                    yield audit
+                    audit_buffer.append(audit)
 
+                    if len(audit_buffer) >= 10:
+                        for a in audit_buffer:
+                            yield a
+                        audit_buffer = []
+        if ticket_buffer:
+            for t in ticket_buffer:
+                yield t
+        if audit_buffer:
+            for a in audit_buffer:
+                yield a
 
 class TicketAudits(Stream):
     name = "ticket_audits"
     replication_method = "INCREMENTAL"
-    replication_key = "created_at"
-
+    oldest_date = utils.strptime_with_tz('2018-07-06T18:01:35Z')
+    count = 0
+    
     def sync(self, ticket_id):
-        # TODO: Remove all bookmarking from audits stream
-        #bookmark = self.get_bookmark(state)
-
-        ticket_audits = self.client.tickets.audits(ticket_id=ticket_id)
+        ticket_audits = self.client.tickets.audits(ticket=ticket_id)
         for ticket_audit in ticket_audits:
             ticket_audit_dict = ticket_audit.to_dict()
-            yield ticket_audit_dict
-
-        # NB: Zenpy's audit generator iterates in reverse order (most recent -> least recent)
-        #     reversed(...) will swap the before_cursor and after_cursor to iterate backwards in time
-        #audit_generator = reversed(self.client.tickets.audits())
-
-        #for audit in audit_generator:
-        #    if utils.strptime_with_tz(audit.created_at) < bookmark:
-        #        break
-        #    self.update_bookmark(state, audit.created_at)
-        #    yield audit
+            self.count += 1
+                
+            if utils.strptime_with_tz(ticket_audit_dict["created_at"]) < self.oldest_date:
+                self.oldest_date = utils.strptime_with_tz(ticket_audit_dict["created_at"])
+            yield (self.stream, ticket_audit_dict)
 
 class Groups(Stream):
     name = "groups"
@@ -196,7 +207,7 @@ class Groups(Stream):
         for group in groups:
             if utils.strptime_with_tz(group.updated_at) >= bookmark:
                 self.update_bookmark(state, group.updated_at)
-                yield group
+                yield (self.stream, group)
 
 class Macros(Stream):
     name = "macros"
@@ -210,7 +221,7 @@ class Macros(Stream):
         for macro in macros:
             if utils.strptime_with_tz(macro.updated_at) >= bookmark:
                 self.update_bookmark(state, macro.updated_at)
-                yield macro
+                yield (self.stream, macro)
 
 class Tags(Stream):
     name = "tags"
@@ -234,7 +245,7 @@ class TicketFields(Stream):
         for field in fields:
             if utils.strptime_with_tz(field.updated_at) >= bookmark:
                 self.update_bookmark(state, field.updated_at)
-                yield field
+                yield (self.stream, field)
 
 class TicketMetrics(Stream):
     name = "ticket_metrics"
@@ -248,7 +259,7 @@ class TicketMetrics(Stream):
         for ticket_metric in ticket_metrics:
             if utils.strptime_with_tz(ticket_metric.updated_at) >= bookmark:
                 self.update_bookmark(state, ticket_metric.updated_at)
-                yield ticket_metric
+                yield (self.stream, ticket_metric)
 
 class GroupMemberships(Stream):
     name = "group_memberships"
@@ -262,7 +273,7 @@ class GroupMemberships(Stream):
         for membership in memberships:
             if utils.strptime_with_tz(membership.updated_at) >= bookmark:
                 self.update_bookmark(state, membership.updated_at)
-                yield membership
+                yield (self.stream, membership)
 
 
 STREAMS = {

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -188,7 +188,7 @@ class Tickets(Stream):
 
             if audits_stream.is_selected():
                 if ticket_dict["status"] == "deleted":
-                    LOGGER.warn("Unable to retrieve audits for deleted ticket (ID: %s), skipping...", ticket_dict["id"])
+                    LOGGER.warning("Unable to retrieve audits for deleted ticket (ID: %s), skipping...", ticket_dict["id"])
                     continue
                 for audit in audits_stream.sync(ticket_dict["id"]):
                     should_yield = self._buffer_record(audit_buffer, audit)
@@ -210,13 +210,13 @@ class TicketAudits(Stream):
     replication_method = "INCREMENTAL"
     oldest_date = utils.strptime_with_tz('2018-07-06T18:01:35Z')
     count = 0
-    
+
     def sync(self, ticket_id):
         ticket_audits = self.client.tickets.audits(ticket=ticket_id)
         for ticket_audit in ticket_audits:
             ticket_audit_dict = ticket_audit.to_dict()
             self.count += 1
-                
+
             if utils.strptime_with_tz(ticket_audit_dict["created_at"]) < self.oldest_date:
                 self.oldest_date = utils.strptime_with_tz(ticket_audit_dict["created_at"])
             yield (self.stream, ticket_audit_dict)

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -1,8 +1,8 @@
 import os
 import json
-import singer
 import datetime
 import pytz
+import singer
 
 from singer import metadata
 from singer import utils

--- a/tap_zendesk/sync.py
+++ b/tap_zendesk/sync.py
@@ -16,26 +16,26 @@ def process_record(record):
     return rec_dict
 
 def sync_stream(client, state, start_date, instance):
-    stream = instance.stream.to_dict()
+    stream = instance.stream
 
     # If we have a bookmark, use it; otherwise use start_date
     if (instance.replication_method == 'INCREMENTAL' and
-            not state.get('bookmarks', {}).get(stream['tap_stream_id'])):
+            not state.get('bookmarks', {}).get(stream.tap_stream_id)):
         singer.write_bookmark(state,
-                              stream['tap_stream_id'],
+                              stream.tap_stream_id,
                               instance.replication_key,
                               start_date)
 
-    with metrics.record_counter(stream['tap_stream_id']) as counter:
-        for record in instance.sync(state):
+    with metrics.record_counter(stream.tap_stream_id) as counter:
+        for (stream, record) in instance.sync(state):
             counter.increment()
 
             rec = process_record(record)
             # SCHEMA_GEN: Comment out transform
             with Transformer() as transformer:
-                rec = transformer.transform(rec, stream['schema'], metadata.to_map(stream['metadata']))
+                rec = transformer.transform(rec, stream.schema.to_dict(), metadata.to_map(stream.metadata))
 
-            singer.write_record(stream['tap_stream_id'], rec)
+            singer.write_record(stream.tap_stream_id, rec)
             # NB: We will only write state at the end of a stream's sync:
             #  We may find out that there exists a sync that takes too long and can never emit a bookmark
             #  but we don't know if we can guarentee the order of emitted records.

--- a/tap_zendesk/sync.py
+++ b/tap_zendesk/sync.py
@@ -1,11 +1,11 @@
 import json
-import singer
-import singer.metrics as metrics
-
-from singer import metadata
-from singer import Transformer
 from zenpy.lib.api_objects import BaseObject
 from zenpy.lib.proxy import ProxyList
+
+import singer
+import singer.metrics as metrics
+from singer import metadata
+from singer import Transformer
 
 LOGGER = singer.get_logger()
 

--- a/tap_zendesk/sync.py
+++ b/tap_zendesk/sync.py
@@ -6,7 +6,6 @@ from singer import metadata
 from singer import Transformer
 from zenpy.lib.api_objects import BaseObject
 from zenpy.lib.proxy import ProxyList
-from tap_zendesk.streams import STREAMS
 
 LOGGER = singer.get_logger()
 
@@ -16,9 +15,9 @@ def process_record(record):
     rec_dict = json.loads(rec_str)
     return rec_dict
 
-def sync_stream(client, state, start_date, stream):
-    instance = STREAMS[stream['tap_stream_id']](client)
-
+def sync_stream(client, state, start_date, instance):
+    stream = instance.stream.to_dict()
+    
     # If we have a bookmark, use it; otherwise use start_date
     if (instance.replication_method == 'INCREMENTAL' and
             not state.get('bookmarks', {}).get(stream['tap_stream_id'])):

--- a/tap_zendesk/sync.py
+++ b/tap_zendesk/sync.py
@@ -15,7 +15,7 @@ def process_record(record):
     rec_dict = json.loads(rec_str)
     return rec_dict
 
-def sync_stream(client, state, start_date, instance):
+def sync_stream(state, start_date, instance):
     stream = instance.stream
 
     # If we have a bookmark, use it; otherwise use start_date

--- a/tap_zendesk/sync.py
+++ b/tap_zendesk/sync.py
@@ -26,9 +26,12 @@ def sync_stream(client, state, start_date, instance):
                               instance.replication_key,
                               start_date)
 
+    parent_stream = stream
     with metrics.record_counter(stream.tap_stream_id) as counter:
         for (stream, record) in instance.sync(state):
-            counter.increment()
+            # NB: Only count parent records in the case of sub-streams
+            if stream.tap_stream_id == parent_stream.tap_stream_id:
+                counter.increment()
 
             rec = process_record(record)
             # SCHEMA_GEN: Comment out transform

--- a/tap_zendesk/sync.py
+++ b/tap_zendesk/sync.py
@@ -17,7 +17,7 @@ def process_record(record):
 
 def sync_stream(client, state, start_date, instance):
     stream = instance.stream.to_dict()
-    
+
     # If we have a bookmark, use it; otherwise use start_date
     if (instance.replication_method == 'INCREMENTAL' and
             not state.get('bookmarks', {}).get(stream['tap_stream_id'])):


### PR DESCRIPTION
The zendesk endpoint to get all ticket audits does not return audits for archived tickets (tickets are archived after 4 months).  

This PR changes the logic for getting all ticket_audits --  we request all tickets, loop over the tickets, and fetch the audits for each ticket.

Also addresses [#10](https://github.com/singer-io/tap-zendesk/issues/10) and [#11](https://github.com/singer-io/tap-zendesk/issues/11)