### PR TITLE
Fix refs and group memberships

### DIFF
--- a/tap_zendesk/discover.py
+++ b/tap_zendesk/discover.py
@@ -7,7 +7,8 @@ def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
 def load_shared_schema_refs():
-    shared_schemas_path = get_abs_path('schemas/shared')
+    ref_sub_path = 'shared'
+    shared_schemas_path = get_abs_path('schemas/' + ref_sub_path)
 
     shared_file_names = [f for f in os.listdir(shared_schemas_path)
                          if os.path.isfile(os.path.join(shared_schemas_path, f))]
@@ -15,7 +16,7 @@ def load_shared_schema_refs():
     shared_schema_refs = {}
     for shared_file in shared_file_names:
         with open(os.path.join(shared_schemas_path, shared_file)) as data_file:
-            shared_schema_refs[shared_file] = json.load(data_file)
+            shared_schema_refs[ref_sub_path + '/' + shared_file] = json.load(data_file)
 
     return shared_schema_refs
 

--- a/tap_zendesk/schemas/shared/metadata.json
+++ b/tap_zendesk/schemas/shared/metadata.json
@@ -1,145 +1,143 @@
 {
-  "metadata": {
-    "type": [
-      "null",
-      "object"
-    ],
-    "properties": {
-      "custom": {},
-      "trusted": {
+  "type": [
+    "null",
+    "object"
+  ],
+  "properties": {
+    "custom": {},
+    "trusted": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "notifications_suppressed_for": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
         "type": [
           "null",
-          "boolean"
+          "integer"
         ]
-      },
-      "notifications_suppressed_for": {
-        "type": [
-          "null",
-          "array"
-        ],
-        "items": {
+      }
+    },
+    "flags_options": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "2": {
           "type": [
             "null",
-            "integer"
-          ]
-        }
-      },
-      "flags_options": {
-        "type": [
-          "null",
-          "object"
-        ],
-        "properties": {
-          "2": {
-            "type": [
-              "null",
-              "object"
-            ],
-            "properties": {
-              "trusted": {
-                "type": [
-                  "null",
-                  "boolean"
-                ]
-              }
+            "object"
+          ],
+          "properties": {
+            "trusted": {
+              "type": [
+                "null",
+                "boolean"
+              ]
             }
-          },
-          "11": {
-            "type": [
-              "null",
-              "object"
-            ],
-            "properties": {
-              "trusted": {
-                "type": [
-                  "null",
-                  "boolean"
-                ]
-              },
-              "message": {
-                "type": [
-                  "null",
-                  "object"
-                ],
-                "properties": {
-                  "user": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  }
+          }
+        },
+        "11": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "trusted": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "message": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "user": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 }
               }
             }
           }
         }
-      },
-      "flags": {
+      }
+    },
+    "flags": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
         "type": [
           "null",
-          "array"
-        ],
-        "items": {
+          "integer"
+        ]
+      }
+    },
+    "system": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "location": {
           "type": [
             "null",
-            "integer"
+            "string"
           ]
-        }
-      },
-      "system": {
-        "type": [
-          "null",
-          "object"
-        ],
-        "properties": {
-          "location": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "longitude": {
-            "type": [
-              "null",
-              "number"
-            ]
-          },
-          "message_id": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "raw_email_identifier": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "ip_address": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "json_email_identifier": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "client": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "latitude": {
-            "type": [
-              "null",
-              "number"
-            ]
-          }
+        },
+        "longitude": {
+          "type": [
+            "null",
+            "number"
+          ]
+        },
+        "message_id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "raw_email_identifier": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "ip_address": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "json_email_identifier": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "client": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "latitude": {
+          "type": [
+            "null",
+            "number"
+          ]
         }
       }
     }

--- a/tap_zendesk/schemas/shared/via.json
+++ b/tap_zendesk/schemas/shared/via.json
@@ -1,122 +1,120 @@
 {
-  "via": {
-    "type": [
-      "null",
-      "object"
-    ],
-    "properties": {
-      "channel": {
-        "type": [
-          "null",
-          "string"
-        ]
-      },
-      "source": {
-        "type": [
-          "null",
-          "object"
-        ],
-        "properties": {
-          "from": {
-            "type": [
-              "null",
-              "object"
-            ],
-            "properties": {
-              "ticket_ids": {
-                "type": [
-                  "null",
-                  "array"
-                ],
-                "items": {
-                  "type": [
-                    "null",
-                    "integer"
-                  ]
-                }
-              },
-              "subject": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "name": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "address": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "original_recipients": {
-                "type": [
-                  "null",
-                  "array"
-                ],
-                "items": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                }
-              },
-              "id": {
+  "type": [
+    "null",
+    "object"
+  ],
+  "properties": {
+    "channel": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "source": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "from": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "ticket_ids": {
+              "type": [
+                "null",
+                "array"
+              ],
+              "items": {
                 "type": [
                   "null",
                   "integer"
                 ]
-              },
-              "ticket_id": {
-                "type": [
-                  "null",
-                  "integer"
-                ]
-              },
-              "deleted": {
-                "type": [
-                  "null",
-                  "boolean"
-                ]
-              },
-              "title": {
+              }
+            },
+            "subject": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "address": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "original_recipients": {
+              "type": [
+                "null",
+                "array"
+              ],
+              "items": {
                 "type": [
                   "null",
                   "string"
                 ]
               }
+            },
+            "id": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "ticket_id": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "deleted": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "title": {
+              "type": [
+                "null",
+                "string"
+              ]
             }
-          },
-          "to": {
-            "type": [
-              "null",
-              "object"
-            ],
-            "properties": {
-              "name": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "address": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          },
-          "rel": {
-            "type": [
-              "null",
-              "string"
-            ]
           }
+        },
+        "to": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "address": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        },
+        "rel": {
+          "type": [
+            "null",
+            "string"
+          ]
         }
       }
     }

--- a/tap_zendesk/schemas/ticket_comments.json
+++ b/tap_zendesk/schemas/ticket_comments.json
@@ -55,9 +55,9 @@
         "integer"
       ]
     },
-    "via": {"$ref": "via.json"},
-    "metadata": {"$ref": "metadata.json"},
-    "attachments": {"$ref": "attachments.json"}
+    "via": {"$ref": "shared/via.json"},
+    "metadata": {"$ref": "shared/metadata.json"},
+    "attachments": {"$ref": "shared/attachments.json"}
   },
   "type": [
     "null",

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -359,10 +359,18 @@ class GroupMemberships(Stream):
 
         memberships = self.client.group_memberships()
         for membership in memberships:
-            if utils.strptime_with_tz(membership.updated_at) >= bookmark:
-                self.update_bookmark(state, membership.updated_at)
-                yield (self.stream, membership)
-
+            # some group memberships come back without an updated_at
+            if membership.updated_at:
+                if utils.strptime_with_tz(membership.updated_at) >= bookmark:
+                    self.update_bookmark(state, membership.updated_at)
+                    yield (self.stream, membership)
+            else:
+                if membership.id:
+                    LOGGER.info('group_membership record with id: ' + str(membership.id) +
+                                ' does not have an updated_at field so it will be syncd...')
+                    yield (self.stream, membership)
+                else:
+                    LOGGER.info('Received group_membership record with no id or updated_at, skipping...')
 
 STREAMS = {
     "tickets": Tickets,


### PR DESCRIPTION
- Fixes a bug where some `group_membership` records were being returned without an `updated_at` field.  The solution is to check for the `updated_at`, and if it is not present, log an info message and sync it.  This means records without an `updated_at` field will be sync'd on every run.
- Fixes schema refs by adding `shared/`