### PR TITLE
Add SLA Policy stream

### DIFF
--- a/tap_zendesk/schemas/sla_policies.json
+++ b/tap_zendesk/schemas/sla_policies.json
@@ -1,95 +1,95 @@
 {
-	"properties": {
-		"id": {
-			"type": [
-				"integer"
-			]
-		},
-		"url": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"title": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"description": {
-			"type": [
-				"null",
-				"string"
-			]
-		},
-		"position": {
-			"type": [
-				"null",
-				"integer"
-			]
-		},
-		"filter": {
-			"properties": {
-				"all": {
-					"type": ["null", "array"],
-					"items": {
-						"properties": {
-							"field": { "type": ["string"] },
-							"operator": { "type": ["string"] },
-							"value": { "type": ["string"] }
-						},
-						"type": ["object"]
-					}
-				},
-				"any": {
-					"type": ["null", "array"],
-					"items": {
-						"properties": {
-							"field": { "type": ["string"] },
-							"operator": { "type": ["string"] },
-							"value": { "type": ["string"] }
-						},
-						"type": ["object"]
-					}
-				}
-			},
-			"type": ["null", "object"]
-		},
-		"policy_metrics": {
-			"type": [
-				"null",
-				"array"
-			],
-			"items": {
-				"properties": {
-					"priority": { "type": ["null", "string"] },
-					"target": { "type": ["null", "integer"] },
-					"business_hours": { "type": ["null", "boolean"] },
-					"metric": { }
-				},
-				"type": [
-					"null",
-					"object"
-				]
-			}
-		},
-		"created_at": {
+  "properties": {
+    "id": {
+      "type": [
+        "integer"
+      ]
+    },
+    "url": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "title": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "description": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "position": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "filter": {
+      "properties": {
+        "all": {
+          "type": ["null", "array"],
+          "items": {
+            "properties": {
+              "field": { "type": ["string"] },
+              "operator": { "type": ["string"] },
+              "value": { "type": ["string"] }
+            },
+            "type": ["object"]
+          }
+        },
+        "any": {
+          "type": ["null", "array"],
+          "items": {
+            "properties": {
+              "field": { "type": ["string"] },
+              "operator": { "type": ["string"] },
+              "value": { "type": ["string"] }
+            },
+            "type": ["object"]
+          }
+        }
+      },
+      "type": ["null", "object"]
+    },
+    "policy_metrics": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "properties": {
+          "priority": { "type": ["null", "string"] },
+          "target": { "type": ["null", "integer"] },
+          "business_hours": { "type": ["null", "boolean"] },
+          "metric": { }
+        },
+        "type": [
+          "null",
+          "object"
+        ]
+      }
+    },
+    "created_at": {
       "type": [
         "null",
         "string"
       ],
       "format": "date-time"
-		},
-		"updated_at": {
+    },
+    "updated_at": {
       "type": [
         "null",
         "string"
       ],
       "format": "date-time"
-		}
-	},
-	"type": [
-		"object"
-	]
+    }
+  },
+  "type": [
+    "object"
+  ]
 }

--- a/tap_zendesk/schemas/sla_policies.json
+++ b/tap_zendesk/schemas/sla_policies.json
@@ -1,0 +1,95 @@
+{
+	"properties": {
+		"id": {
+			"type": [
+				"integer"
+			]
+		},
+		"url": {
+			"type": [
+				"null",
+				"string"
+			]
+		},
+		"title": {
+			"type": [
+				"null",
+				"string"
+			]
+		},
+		"description": {
+			"type": [
+				"null",
+				"string"
+			]
+		},
+		"position": {
+			"type": [
+				"null",
+				"integer"
+			]
+		},
+		"filter": {
+			"properties": {
+				"all": {
+					"type": ["null", "array"],
+					"items": {
+						"properties": {
+							"field": { "type": ["string"] },
+							"operator": { "type": ["string"] },
+							"value": { "type": ["string"] }
+						},
+						"type": ["object"]
+					}
+				},
+				"any": {
+					"type": ["null", "array"],
+					"items": {
+						"properties": {
+							"field": { "type": ["string"] },
+							"operator": { "type": ["string"] },
+							"value": { "type": ["string"] }
+						},
+						"type": ["object"]
+					}
+				}
+			},
+			"type": ["null", "object"]
+		},
+		"policy_metrics": {
+			"type": [
+				"null",
+				"array"
+			],
+			"items": {
+				"properties": {
+					"priority": { "type": ["null", "string"] },
+					"target": { "type": ["null", "integer"] },
+					"business_hours": { "type": ["null", "boolean"] },
+					"metric": { }
+				},
+				"type": [
+					"null",
+					"object"
+				]
+			}
+		},
+		"created_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+		},
+		"updated_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+		}
+	},
+	"type": [
+		"object"
+	]
+}

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -412,6 +412,14 @@ class GroupMemberships(Stream):
                 else:
                     LOGGER.info('Received group_membership record with no id or updated_at, skipping...')
 
+class SLAPolicies(Stream):
+    name = "sla_policies"
+    replication_method = "FULL_TABLE"
+
+    def sync(self, state):
+        for policy in self.client.sla_policies():
+            yield (self.stream, policy)
+
 STREAMS = {
     "tickets": Tickets,
     "groups": Groups,
@@ -425,5 +433,6 @@ STREAMS = {
     "macros": Macros,
     "satisfaction_ratings": SatisfactionRatings,
     "tags": Tags,
-    "ticket_metrics": TicketMetrics
+    "ticket_metrics": TicketMetrics,
+    "sla_policies": SLAPolicies,
 }


### PR DESCRIPTION
This PR adds the `sla_policies` stream according to https://developer.zendesk.com/rest_api/docs/core/sla_policies#sla-policies.

This uses Zenpy SlaPolicy API and should conform to the rest of the streams.
I've tried to make the JSONSchema as narrow as possible.