### PR TITLE
add ticket_id to ticket_comments stream

### DIFF
--- a/tap_zendesk/schemas/ticket_comments.json
+++ b/tap_zendesk/schemas/ticket_comments.json
@@ -19,6 +19,12 @@
         "integer"
       ]
     },
+    "ticket_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
     "type": {
       "type": [
         "null",

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -236,8 +236,10 @@ class Tickets(Stream):
 
             if comments_stream.is_selected():
                 try:
+                    # add ticket_id to ticket_comment so the comment can
+                    # be linked back to it's corresponding ticket
                     for comment in comments_stream.sync(ticket_dict["id"]):
-                        comment["ticket_id"] = ticket_dict["id"]
+                        comment[1].ticket_id = ticket_dict["id"]
                         self._buffer_record(comment)
                 except RecordNotFoundException:
                     LOGGER.warning("Unable to retrieve comments for ticket (ID: %s), " \

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -237,6 +237,7 @@ class Tickets(Stream):
             if comments_stream.is_selected():
                 try:
                     for comment in comments_stream.sync(ticket_dict["id"]):
+                        comment["ticket_id"] = ticket_dict["id"]
                         self._buffer_record(comment)
                 except RecordNotFoundException:
                     LOGGER.warning("Unable to retrieve comments for ticket (ID: %s), " \

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -419,7 +419,7 @@ class SLAPolicies(Stream):
     name = "sla_policies"
     replication_method = "FULL_TABLE"
 
-    def sync(self, state):
+    def sync(self, state): # pylint: disable=unused-argument
         for policy in self.client.sla_policies():
             yield (self.stream, policy)
 


### PR DESCRIPTION
Adds `ticket_id` to `ticket_comments` stream so users can link the comments back to corresponding ticket.