### PR TITLE
Add option to specify partner config and test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
+.PHONY: test
 .DEFAULT_GOAL := test
 
 test:
 	pylint tap_zendesk -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme,stop-iteration-return,too-many-branches,useless-import-alias,no-else-return,logging-not-lazy
+	nosetests

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ setup(name='tap-zendesk',
           'dev': [
               'ipdb',
               'pylint',
+              'nose',
+              'nose-watch',
           ]
       },
       entry_points='''

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -1,0 +1,23 @@
+import unittest
+from tap_zendesk import get_session
+
+class TestGetSession(unittest.TestCase):
+    """
+    Confirm that partner information is added to session headers when
+    present in config.
+    """
+    def test_no_partner_info_returns_none(self):
+        test_session = get_session({})
+        self.assertEqual(test_session, None)
+
+    def test_incomplete_partner_info_returns_none(self):
+        test_session = get_session({"marketplace_name": "Hithere"})
+        self.assertEqual(test_session, None)
+
+    def test_adds_headers_when_all_present_in_config(self):
+        test_session = get_session({"marketplace_name": "Hithere",
+                                    "marketplace_organization_id": 1234,
+                                    "marketplace_app_id": 12345})
+        self.assertEqual("Hithere", test_session.headers.get("X-Zendesk-Marketplace-Name"))
+        self.assertEqual("1234", test_session.headers.get("X-Zendesk-Marketplace-Organization-Id"))
+        self.assertEqual("12345", test_session.headers.get("X-Zendesk-Marketplace-App-Id"))


### PR DESCRIPTION
In order to properly use a Partner app with the Zendesk API, some headers need to be specified with each request as outlined [in this article](https://develop.zendesk.com/hc/en-us/articles/360001934648).

This PR gives the option of adding these three values in the config using the keys `["marketplace_name", "marketplace_organization_id", "marketplace_app_id"]`.