### PR TITLE
Reduce log noise

### DIFF
--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -2,16 +2,16 @@
 import json
 import sys
 
+from zenpy import Zenpy
 import requests
-import singer
 from requests import Session
 from requests.adapters import HTTPAdapter
+import singer
 from singer import metadata, metrics as singer_metrics
 from tap_zendesk import metrics as zendesk_metrics
 from tap_zendesk.discover import discover_streams
 from tap_zendesk.streams import STREAMS
 from tap_zendesk.sync import sync_stream
-from zenpy import Zenpy
 
 LOGGER = singer.get_logger()
 

--- a/tap_zendesk/sync.py
+++ b/tap_zendesk/sync.py
@@ -27,7 +27,7 @@ def sync_stream(state, start_date, instance):
                               start_date)
 
     parent_stream = stream
-    with metrics.record_counter(stream.tap_stream_id) as counter:
+    with metrics.record_counter(stream.tap_stream_id) as counter, Transformer() as transformer:
         for (stream, record) in instance.sync(state):
             # NB: Only count parent records in the case of sub-streams
             if stream.tap_stream_id == parent_stream.tap_stream_id:
@@ -35,8 +35,7 @@ def sync_stream(state, start_date, instance):
 
             rec = process_record(record)
             # SCHEMA_GEN: Comment out transform
-            with Transformer() as transformer:
-                rec = transformer.transform(rec, stream.schema.to_dict(), metadata.to_map(stream.metadata))
+            rec = transformer.transform(rec, stream.schema.to_dict(), metadata.to_map(stream.metadata))
 
             singer.write_record(stream.tap_stream_id, rec)
             # NB: We will only write state at the end of a stream's sync:


### PR DESCRIPTION
The `Transformer` was being created for each record, but now we create it once per stream.