### PR TITLE
removed metric field from ticket_metrics.json

### DIFF
--- a/tap_zendesk/schemas/ticket_metrics.json
+++ b/tap_zendesk/schemas/ticket_metrics.json
@@ -1,11 +1,5 @@
 {
   "properties": {
-    "metric": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "id": {
       "type": [
         "null",


### PR DESCRIPTION
# Description of change
removed metric field from ticket_metrics.json since the metric field doesn't come through in records

# Manual QA steps
 locally:
   ran discovery, selected all fields (including metric)
  ensured that the records came through but the metric field didn't come through for any of them
  made change, re-ran discovery
  ensured metric field didn't show up in ui
  selected all fields
  re-ran sync, ensured all records came through just the same
 
# Risks
 - low
 
# Rollback steps
 - revert this branch
