### PR TITLE
Add description default to groups schema

### DIFF
--- a/tap_zendesk/schemas/groups.json
+++ b/tap_zendesk/schemas/groups.json
@@ -10,6 +10,12 @@
         "string"
       ]
     },
+    "description": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "created_at": {
       "type": [
         "null",

--- a/tap_zendesk/schemas/groups.json
+++ b/tap_zendesk/schemas/groups.json
@@ -10,12 +10,6 @@
         "string"
       ]
     },
-    "description": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "created_at": {
       "type": [
         "null",
@@ -46,6 +40,18 @@
       "type": [
         "null",
         "integer"
+      ]
+    },
+    "default": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "description": {
+      "type": [
+        "null",
+        "string"
       ]
     }
   }


### PR DESCRIPTION
# Description of change
`default` and `description` are two fields available in the [Zendesk Support API for the groups entity](https://developer.zendesk.com/rest_api/docs/support/groups). 
They are currently not available in the `tap-zendesk` schema for `groups`. This PR is adding them.

# Manual QA steps
 - Ran `tap-zendesk` locally 
```
WARNING Removed 2 paths during transforms:
    default
    description
WARNING Removed paths list: ['default', 'description']
```
  - Ran `tap-zendesk` with branch `add_description_default_to_groups_schema` locally
  -> No `WARNING`. All fields, including `default` and `description` have been pulled.

# Risks
 - Very low. 
 
# Rollback steps
 - Revert this branch
