### PR TITLE
use proper env, move build time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run:
           name: 'Integration Tests'
           command: |
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             run-test --tap=tap-zendesk \
@@ -46,7 +46,7 @@ workflows:
   build_daily:
     triggers:
       - schedule:
-          cron: "0 13 * * *"
+          cron: "0 6 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
# Description of change
Use the tap_tester_sandbox environment and move the build time to avoid collisions.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
