### PR TITLE
add ticket metric events stream for zendesk

### DIFF
--- a/tap_zendesk/schemas/ticket_metric_events.json
+++ b/tap_zendesk/schemas/ticket_metric_events.json
@@ -1,0 +1,116 @@
+{
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "instance_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "metric": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ticket_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "time": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "sla": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "target": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "business_hours": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "policy": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "title": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "description": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "calendar": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "business": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        }
+      }
+    },
+    "deleted": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    }
+  },
+  "type": [
+    "null",
+    "object"
+  ]
+}

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -342,6 +342,29 @@ class TicketMetrics(Stream):
         self.count += 1
         yield (self.stream, ticket_metric)
 
+class TicketMetricEvents(Stream):
+    name = "ticket_metric_events"
+    replication_method = "INCREMENTAL"
+    replication_key = "time"
+    count = 0
+
+    def sync(self, state):
+        bookmark = self.get_bookmark(state)
+        start = bookmark - datetime.timedelta(seconds=1)
+
+        epoch_start = int(start.strftime('%s'))
+        parsed_start = singer.strftime(start, "%Y-%m-%dT%H:%M:%SZ")
+        ticket_metric_events = self.client.tickets.metrics_incremental(start_time=epoch_start)
+        for event in ticket_metric_events:
+            self.count += 1
+            assert parsed_start <= event.time, "TicketMetricEvents - Record found out of time order. Details: start ({}) is not less than or equal to event.time ({})".format(parsed_start, satisfaction_rating.updated_at)
+            if bookmark < utils.strptime_with_tz(event.time):
+                self.update_bookmark(state, event.time)
+            if parsed_start <= event.time:
+                yield (self.stream, event)
+            # if self.count%5000 == 0:
+            #     LOGGER.info("Latest row at {time_at}".format(time_at=event.time))
+
 class TicketComments(Stream):
     name = "ticket_comments"
     replication_method = "INCREMENTAL"
@@ -539,5 +562,6 @@ STREAMS = {
     "satisfaction_ratings": SatisfactionRatings,
     "tags": Tags,
     "ticket_metrics": TicketMetrics,
+    "ticket_metric_events": TicketMetricEvents,
     "sla_policies": SLAPolicies,
 }


### PR DESCRIPTION
# Description of change
Currently singer Zendesk tap does not provide a method for "Ticket Metric Events"
* API reference: https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_metric_events/
* Table Documentation: https://developer.zendesk.com/documentation/ticketing/reference-guides/ticket-metric-event-types-reference/


# Manual QA steps
* Ran `tap-zendesk` locally.
 
# Risks
* Very low as no change to code, only adding new functions.
 
# Rollback steps
* revert this branch.
