### PR TITLE
v1.5.4: Log request URL, etag, and request ID for debugging purposes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.5.4
+  * Log Request URL (and URL params), Response ETag, and Response 'X-Request-Id' header to help with troubleshooting [#63](https://github.com/singer-io/tap-zendesk/pull/63)
+
 ## 1.5.3
   * Break out of infinite loop with users stream and bookmark on date window end [#46](https://github.com/singer-io/tap-zendesk/pull/46)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='1.5.3',
+      version='1.5.4',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -37,7 +37,10 @@ request = Session.request
 def request_metrics_patch(self, method, url, **kwargs):
     with singer_metrics.http_request_timer(None):
         response = request(self, method, url, **kwargs)
-        LOGGER.info("Request: %s, Response ETag: %s, Request Id: %s", url, response.headers['ETag'], response.headers['X-Request-Id'])
+        LOGGER.info("Request: %s, Response ETag: %s, Request Id: %s",
+                    url,
+                    response.headers.get('ETag', 'Not present'),
+                    response.headers.get('X-Request-Id', 'Not present'))
         return response
 
 Session.request = request_metrics_patch

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -36,7 +36,9 @@ request = Session.request
 
 def request_metrics_patch(self, method, url, **kwargs):
     with singer_metrics.http_request_timer(None):
-        return request(self, method, url, **kwargs)
+        response = request(self, method, url, **kwargs)
+        LOGGER.info("Request: %s, Response ETag: %s, Request Id: %s", url, response.headers['ETag'], response.headers['X-Request-Id'])
+        return response
 
 Session.request = request_metrics_patch
 # end patch


### PR DESCRIPTION
# Description of change
This PR adds logging around every request of the URL, the response ETag, and the Request ID in order to pass these values along to Zendesk support in the event of an error.

# Manual QA steps
 - Relying on tests to run a sync for every stream
 - Manually tested with the Users stream to confirm no sensitive information is logged
 
# Risks
 - Low, it's a logging add that's relatively safe (credentials should not be part of the URL string, these are contained within the session itself)
 
# Rollback steps
 - revert this branch
