### PR TITLE
Fix/satisfaction ratings start

### DIFF
--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -29,16 +29,18 @@ def call_api(url, params, headers):
 
 
 
-def get_cursor_based(url, access_token, cursor=None):
+def get_cursor_based(url, access_token, cursor=None, **kwargs):
     # something like this
     headers = {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
         'Authorization': 'Bearer {}'.format(access_token),
+        **kwargs.get('headers', {})
     }
 
     params = {
         'page[size]': 100,
+        **kwargs.get('params', {})
     }
 
     if cursor:

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -380,8 +380,9 @@ class SatisfactionRatings(Stream):
 
     def sync(self, state):
         bookmark = self.get_bookmark(state)
-
-        ratings = self.get_objects()
+        epoch_bookmark = int(bookmark.timestamp())
+        params = {'start_time': epoch_bookmark}
+        ratings = self.get_objects(params=params)
         for rating in ratings:
             if utils.strptime_with_tz(rating['updated_at']) >= bookmark:
                 self.update_bookmark(state, rating['updated_at'])

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -66,13 +66,13 @@ class Stream():
         self.client = client
         self.config = config
 
-    def get_objects(self):
+    def get_objects(self, **kwargs):
         '''
         Cursor based object retrieval
         '''
         url = self.endpoint.format(self.config['subdomain'])
 
-        for page in http.get_cursor_based(url, self.config['access_token']):
+        for page in http.get_cursor_based(url, self.config['access_token'], **kwargs):
             yield from page[self.item_key]
 
     def get_bookmark(self, state):


### PR DESCRIPTION
# Description of change
This PR pulls the bookmark out of the state to pass to the API as the start date for a sync.

There's already logic in the tap to insert the config's start date into state if there is no value present. So this PR doesn't handle any default value logic

# Manual QA steps
 - Ran the tap
 
# Risks
 - I looked through the docs for all of the streams updated in #64 and only Satisfaction Ratings takes a start date param
 
# Rollback steps
 - revert this branch
