### PR TITLE
Remove Zenpy usage for Tickets stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.6.0
+  * Fixing the via.from field on the tickets, and ticket_comments stream [#75](https://github.com/singer-io/tap-zendesk/pull/75)
+    * Remove usage of `zenpy` library for tickets stream and all sub-streams
+
 ## 1.5.8
   * Revert Organizations Stream back to the Incremental Search endpoint [#70](https://github.com/singer-io/tap-zendesk/pull/70)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='1.5.8',
+      version='1.6.0',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',

--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -60,7 +60,7 @@ def get_cursor_based(url, access_token, cursor=None, **kwargs):
         yield response_json
         has_more = response_json['meta']['has_more']
 
-def get_offset_based(url, access_token, cursor=None, **kwargs):
+def get_offset_based(url, access_token, **kwargs):
     headers = {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
@@ -81,7 +81,7 @@ def get_offset_based(url, access_token, cursor=None, **kwargs):
     next_url = response_json.get('next_page')
 
     while next_url:
-        response = call_api(next_url, headers=headers)
+        response = call_api(next_url, params=None, headers=headers)
         response_json = response.json()
 
         yield response_json

--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -27,8 +27,6 @@ def call_api(url, params, headers):
     response.raise_for_status()
     return response
 
-
-
 def get_cursor_based(url, access_token, cursor=None, **kwargs):
     headers = {
         'Content-Type': 'application/json',
@@ -77,9 +75,7 @@ def get_incremental_export(url, access_token, start_time):
 
     yield response_json
 
-    end_of_stream = response_json['end_of_stream']
-
-
+    end_of_stream = response_json.get('end_of_stream')
 
     while not end_of_stream:
         cursor = response_json['after_cursor']
@@ -91,4 +87,4 @@ def get_incremental_export(url, access_token, start_time):
 
         yield response_json
 
-        end_of_stream = response_json['end_of_stream']
+        end_of_stream = response_json.get('end_of_stream')

--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -30,7 +30,6 @@ def call_api(url, params, headers):
 
 
 def get_cursor_based(url, access_token, cursor=None, **kwargs):
-    # something like this
     headers = {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
@@ -63,3 +62,55 @@ def get_cursor_based(url, access_token, cursor=None, **kwargs):
 
         yield response_json
         has_more = response_json['meta']['has_more']
+
+def get_incremental_export(url, access_token, start_time):
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        'Authorization': 'Bearer {}'.format(access_token),
+    }
+
+    params = {'start_time': start_time.timestamp()}
+
+    response = call_api(url, params=params, headers=headers)
+    response_json = response.json()
+
+    yield response_json
+
+    end_of_stream = response_json['end_of_stream']
+
+
+
+    while not end_of_stream:
+        cursor = response_json['after_cursor']
+
+        params = {'cursor': cursor}
+        response = requests.get(url, params=params, headers=headers)
+        response.raise_for_status()
+        response_json = response.json()
+
+        yield response_json
+
+        end_of_stream = response_json['end_of_stream']
+
+
+    # response has a cursor, it also has an end_time
+    #   end_time -> "The most recent time present in the result set expressed as a Unix epoch time. Use as the start_time to fetch the next page of results"
+    # could we use this end_time as a bookmark??
+    # i didn't see 'end_time' on the response, only the 'after_cursor'
+#INFO Request:...
+#INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 8.35524868965149, "tags": {"status": "succeeded"}}
+# ipdb> after_first_sync = set([x['id'] for x in response.json()['tickets']])
+# ipdb> len(after_first_sync)
+# 1000
+# ipdb> c
+#INFO Request:...
+#INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 8.608530044555664, "tags": {"status": "succeeded"}}
+# ipdb> after_second_sync = set([x['id'] for x in response.json()['tickets']])
+# ipdb> len(after_second_sync)
+# 1000
+# ipdb> len(after_second_sync.union(after_first_sync))
+# 2000
+#
+# ^so we're getting 1000 different ids on the second sync
+# so it seems like we're paginating correctly

--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -92,25 +92,3 @@ def get_incremental_export(url, access_token, start_time):
         yield response_json
 
         end_of_stream = response_json['end_of_stream']
-
-
-    # response has a cursor, it also has an end_time
-    #   end_time -> "The most recent time present in the result set expressed as a Unix epoch time. Use as the start_time to fetch the next page of results"
-    # could we use this end_time as a bookmark??
-    # i didn't see 'end_time' on the response, only the 'after_cursor'
-#INFO Request:...
-#INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 8.35524868965149, "tags": {"status": "succeeded"}}
-# ipdb> after_first_sync = set([x['id'] for x in response.json()['tickets']])
-# ipdb> len(after_first_sync)
-# 1000
-# ipdb> c
-#INFO Request:...
-#INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 8.608530044555664, "tags": {"status": "succeeded"}}
-# ipdb> after_second_sync = set([x['id'] for x in response.json()['tickets']])
-# ipdb> len(after_second_sync)
-# 1000
-# ipdb> len(after_second_sync.union(after_first_sync))
-# 2000
-#
-# ^so we're getting 1000 different ids on the second sync
-# so it seems like we're paginating correctly

--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -61,6 +61,39 @@ def get_cursor_based(url, access_token, cursor=None, **kwargs):
         yield response_json
         has_more = response_json['meta']['has_more']
 
+def get_offset_based(url, access_token, cursor=None, **kwargs):
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        'Authorization': 'Bearer {}'.format(access_token),
+        **kwargs.get('headers', {})
+    }
+
+    params = {
+        'per_page': 3,
+        **kwargs.get('params', {})
+    }
+
+    response = call_api(url, params=params, headers=headers)
+    response_json = response.json()
+
+    yield response_json
+
+    has_more = response_json['meta']['next_page']
+
+    while has_more:
+        cursor = response_json['meta']['after_cursor']
+        params['page[after]'] = cursor
+
+        response = requests.get(url, params=params, headers=headers)
+        response.raise_for_status()
+        response_json = response.json()
+
+        yield response_json
+        has_more = response_json['meta']['has_more']
+
+
+
 def get_incremental_export(url, access_token, start_time):
     headers = {
         'Content-Type': 'application/json',

--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -116,7 +116,7 @@ def get_incremental_export(url, access_token, start_time):
         end_of_stream = response_json.get('end_of_stream')
 
 
-def get_simple(url, access_token):
+def get_single_call(url, access_token, params=None):
     headers = {
         'Content-Type': 'application/json',
         'Accept': 'application/json',

--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -69,7 +69,7 @@ def get_offset_based(url, access_token, **kwargs):
     }
 
     params = {
-        'per_page': 3,
+        'per_page': 100,
         **kwargs.get('params', {})
     }
 
@@ -114,16 +114,3 @@ def get_incremental_export(url, access_token, start_time):
         yield response_json
 
         end_of_stream = response_json.get('end_of_stream')
-
-
-def get_single_call(url, access_token, params=None):
-    headers = {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-        'Authorization': 'Bearer {}'.format(access_token),
-    }
-
-    response = call_api(url, params=params, headers=headers)
-    response_json = response.json()
-
-    yield response_json

--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -16,7 +16,7 @@ def is_fatal(exception):
         sleep(sleep_time)
         return False
 
-    return 400 <=status_code < 500
+    return 400 <= status_code < 500
 
 @backoff.on_exception(backoff.expo,
                       requests.exceptions.HTTPError,

--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -54,8 +54,7 @@ def get_cursor_based(url, access_token, cursor=None, **kwargs):
         cursor = response_json['meta']['after_cursor']
         params['page[after]'] = cursor
 
-        response = requests.get(url, params=params, headers=headers)
-        response.raise_for_status()
+        response = call_api(url, params=params, headers=headers)
         response_json = response.json()
 
         yield response_json
@@ -79,20 +78,14 @@ def get_offset_based(url, access_token, cursor=None, **kwargs):
 
     yield response_json
 
-    has_more = response_json['meta']['next_page']
+    next_url = response_json.get('next_page')
 
-    while has_more:
-        cursor = response_json['meta']['after_cursor']
-        params['page[after]'] = cursor
-
-        response = requests.get(url, params=params, headers=headers)
-        response.raise_for_status()
+    while next_url:
+        response = call_api(next_url, headers=headers)
         response_json = response.json()
 
         yield response_json
-        has_more = response_json['meta']['has_more']
-
-
+        next_url = response_json.get('next_page')
 
 def get_incremental_export(url, access_token, start_time):
     headers = {

--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -114,3 +114,16 @@ def get_incremental_export(url, access_token, start_time):
         yield response_json
 
         end_of_stream = response_json.get('end_of_stream')
+
+
+def get_simple(url, access_token):
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        'Authorization': 'Bearer {}'.format(access_token),
+    }
+
+    response = call_api(url, params=params, headers=headers)
+    response_json = response.json()
+
+    yield response_json

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -289,7 +289,7 @@ class Tickets(CursorBasedExportStream):
 
         audits_stream = TicketAudits(self.client)
         metrics_stream = TicketMetrics(self.client)
-        comments_stream = TicketComments(self.client)
+        comments_stream = TicketComments(self.client, self.config)
 
         def emit_sub_stream_metrics(sub_stream):
             if sub_stream.is_selected():
@@ -380,7 +380,7 @@ class TicketComments(Stream):
     name = "ticket_comments"
     replication_method = "INCREMENTAL"
     count = 0
-    endpoint = "https://{}.zendesk.com/api/v2/tickets/{}.json"
+    endpoint = "https://{}.zendesk.com/api/v2/tickets/{}/comments.json"
     item_key='comments'
 
     def get_objects(self, ticket_id):

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -283,7 +283,7 @@ class Tickets(CursorBasedExportStream):
                 yield rec
             self.buf[stream_name] = []
 
-    def sync(self, state):
+    def sync(self, state): #pylint: disable=too-many-statements
         bookmark = self.get_bookmark(state)
         tickets = self.get_objects(bookmark)
 
@@ -335,8 +335,6 @@ class Tickets(CursorBasedExportStream):
                     # add ticket_id to ticket_comment so the comment can
                     # be linked back to it's corresponding ticket
                     for comment in comments_stream.sync(ticket["id"]):
-                        zendesk_metrics.capture('ticket_comment')
-                        comment[1]['ticket_id'] = ticket["id"]
                         self._buffer_record(comment)
                 except HTTPError as e:
                     if e.response.status_code == 404:
@@ -412,6 +410,8 @@ class TicketComments(Stream):
     def sync(self, ticket_id):
         for ticket_comment in self.get_objects(ticket_id):
             self.count += 1
+            zendesk_metrics.capture('ticket_comment')
+            ticket_comment['ticket_id'] = ticket_id
             yield (self.stream, ticket_comment)
 
 class SatisfactionRatings(CursorBasedStream):

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -314,7 +314,6 @@ class Tickets(CursorBasedExportStream):
             if audits_stream.is_selected():
                 try:
                     for audit in audits_stream.sync(ticket["id"]):
-                        zendesk_metrics.capture('ticket_audit')
                         self._buffer_record(audit)
                 except RecordNotFoundException:
                     LOGGER.warning("Unable to retrieve audits for ticket (ID: %s), " \
@@ -329,7 +328,6 @@ class Tickets(CursorBasedExportStream):
             if metrics_stream.is_selected():
                 try:
                     for metric in metrics_stream.sync(ticket["id"]):
-                        zendesk_metrics.capture('ticket_metric')
                         self._buffer_record(metric)
                 except RecordNotFoundException:
                     LOGGER.warning("Unable to retrieve metrics for ticket (ID: %s), " \
@@ -378,6 +376,7 @@ class TicketAudits(Stream):
     def sync(self, ticket_id):
         ticket_audits = self.get_objects(ticket_id)
         for ticket_audit in ticket_audits:
+            zendesk_metrics.capture('ticket_audit')
             self.count += 1
             yield (self.stream, ticket_audit)
 
@@ -388,6 +387,7 @@ class TicketMetrics(Stream):
 
     def sync(self, ticket_id):
         ticket_metric = self.client.tickets.metrics(ticket=ticket_id)
+        zendesk_metrics.capture('ticket_metric')
         self.count += 1
         yield (self.stream, ticket_metric)
 

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -385,7 +385,7 @@ class TicketComments(Stream):
 
     def get_objects(self, ticket_id):
         url = self.endpoint.format(self.config['subdomain'], ticket_id)
-        pages = http.get_cursor_based(url, self.config['access_token'])
+        pages = http.get_offset_based(url, self.config['access_token'])
 
         for page in pages:
             yield from page[self.item_key]

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -334,7 +334,7 @@ class Tickets(CursorBasedExportStream):
                     # be linked back to it's corresponding ticket
                     for comment in comments_stream.sync(ticket["id"]):
                         zendesk_metrics.capture('ticket_comment')
-                        comment[1].ticket_id = ticket["id"]
+                        comment[1]['ticket_id'] = ticket["id"]
                         self._buffer_record(comment)
                 except RecordNotFoundException:
                     LOGGER.warning("Unable to retrieve comments for ticket (ID: %s), " \
@@ -355,7 +355,7 @@ class Tickets(CursorBasedExportStream):
         emit_sub_stream_metrics(comments_stream)
         singer.write_state(state)
 
-class TicketAudits(Stream):
+class TicketAudits(Stream):# TODO: implement cursor-based for this stream
     name = "ticket_audits"
     replication_method = "INCREMENTAL"
     count = 0

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -117,7 +117,7 @@ class Stream():
 class CursorBasedIncrementalStream(Stream):
     endpoint = "https://{}.zendesk.com/api/v2/incremental/{}/cursor.json"
 
-    def get_objects(self, start_time):
+    def get_objects_incremental(self, start_time):
         '''
         Cursor based object retrieval
         '''
@@ -281,7 +281,7 @@ class Tickets(CursorBasedIncrementalStream):
 
     def sync(self, state):
         bookmark = self.get_bookmark(state)
-        tickets = self.get_objects(bookmark)
+        tickets = self.get_objects_incremental(bookmark)
 
         audits_stream = TicketAudits(self.client)
         metrics_stream = TicketMetrics(self.client)

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -369,7 +369,7 @@ class TicketAudits(Stream):
 
     def get_objects(self, ticket_id):
         url = self.endpoint.format(self.config['subdomain'], ticket_id)
-        pages = http.get_single_call(url, self.config['access_token'])
+        pages = http.get_offset_based(url, self.config['access_token'])
         for page in pages:
             yield from page[self.item_key]
 

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -115,10 +115,9 @@ class Stream():
         return self.stream is not None
 
 class CursorBasedIncrementalStream(Stream):
-    # im pretty sure Tickets is the only stream that gets a cursor based incremental export though...
     endpoint = "https://{}.zendesk.com/api/v2/incremental/{}/cursor.json"
 
-o    def get_objects(self, start_time):
+    def get_objects(self, start_time):
         '''
         Cursor based object retrieval
         '''
@@ -126,13 +125,6 @@ o    def get_objects(self, start_time):
 
         for page in http.get_incremental_export(url, self.config['access_token'], start_time):
             yield from page[self.item_key]
-
-# incremental:
-#   tickets:
-#     /api/v2/incremental/tickets/cursor.json?
-#   users:
-#     /api/v2/incremental/users
-#
 
 
 def raise_or_log_zenpy_apiexception(schema, stream, e):

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -381,9 +381,10 @@ class TicketComments(Stream):
     replication_method = "INCREMENTAL"
     count = 0
     endpoint = "https://{}.zendesk.com/api/v2/tickets/{}.json"
+    item_key='comments'
 
     def get_objects(self, ticket_id):
-        url = endpoint.format(self.config['subdomain'], ticket_id)
+        url = self.endpoint.format(self.config['subdomain'], ticket_id)
         pages = http.get_cursor_based(url, self.config['access_token'])
 
         for page in pages:


### PR DESCRIPTION
# Description of change
https://jira.talendforge.org/browse/TDL-15551

Fixing the `via.from` field on the `tickets`,  and `ticket_comments` stream.

The previous version bump on the `zenpy` library changed how the `zenpy` was returning the `via.from` field to `via._from`. To work around this we are dropping the usage of the `zenpy` library for the `tickets` stream and all children streams.

# Manual QA steps
 - tests will run in circle
 - that's it for now
 
# Risks
 - if we implement the sync and pagination correctly, there should be no risks
 
# Rollback steps
 - revert this branch
