### PR TITLE
TDL-16240-failing API request containing user id

### DIFF
--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -222,7 +222,6 @@ class Users(Stream):
 
             # Consume the records to account for dates lower than window start
             users = [user for user in users] # pylint: disable=unnecessary-comprehension
-
             if not all(parsed_start <= user.updated_at for user in users):
                 # Only retry up to 30 minutes (60 attempts at 30 seconds each)
                 if num_retries < 60:
@@ -230,6 +229,8 @@ class Users(Stream):
                     time.sleep(30)
                     num_retries += 1
                     continue
+                #Added by Kris for Card TDL-16240 - To be removed later
+                LOGGER.info([user.id for user in users])
                 bad_users = [user for user in users if user.updated_at < parsed_start]
                 raise AssertionError("users - Record (user-id: {}) found before date window start and did not resolve after 30 minutes of retrying. Details: window start ({}) is not less than or equal to updated_at value(s) {}".format(
                     [user.id for user in bad_users],


### PR DESCRIPTION
# Description of change
Added a simple logger message of user_id's when api request fails. This is for one of the support ticket issue

# Manual QA steps
 - 
 
# Risks
 - This is not a GA release. It is specific to a customer request
 
# Rollback steps
 - revert this branch
