### PR TITLE
Tdl 16369 revert back api access change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           path: htmlcov
       - run:
           name: 'Integration Tests'
-          no_output_timeout: 30m
+          no_output_timeout: 200m
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
           path: htmlcov
       - run:
           name: 'Integration Tests'
+          no_output_timeout: 30m
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh

--- a/tap_zendesk/discover.py
+++ b/tap_zendesk/discover.py
@@ -61,14 +61,16 @@ def discover_streams(client, config):
 
         total_stream = len(STREAMS.values()) # Total no of streams
         streams_name = ", ".join(error_list)
-        message = "The account credentials supplied do not have read access for the following stream(s): {}."\
-            "The data for the mentioned streams will not be collected if selected due to a lack of 'read' permission.".format(streams_name)
         if len(error_list) != total_stream:
+            message = "The account credentials supplied do not have 'read' access to the following stream(s): {}. "\
+                "The data for these streams would not be collected due to lack of required permission.".format(streams_name)
             # If atleast one stream have read permission then just print warning message for all streams
             # which does not have read permission
             LOGGER.warning(message)
         else:
-            # If any one of stream does not have read permission then raise error.
+            message = "HTTP-error-code: 403, Error: You are missing the following required scopes: read. "\
+                    "The account credentials supplied do not have read access for the following stream(s):  {}".format(streams_name)
+            # If none of the streams are having the 'read' access, then the code will raise an error
             raise ZendeskForbiddenError(message)
 
 

--- a/tap_zendesk/discover.py
+++ b/tap_zendesk/discover.py
@@ -68,8 +68,8 @@ def discover_streams(client, config):
             # which does not have read permission
             LOGGER.warning(message)
         else:
-            message = "HTTP-error-code: 403, Error: You are missing the following required scopes: read. "\
-                    "The account credentials supplied do not have read access for the following stream(s):  {}".format(streams_name)
+            message ="HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "\
+            "of streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
             # If none of the streams are having the 'read' access, then the code will raise an error
             raise ZendeskForbiddenError(message)
 

--- a/tap_zendesk/discover.py
+++ b/tap_zendesk/discover.py
@@ -59,17 +59,17 @@ def discover_streams(client, config):
 
     if error_list:
 
-        total_stream = len(STREAMS.values()) # Total no od streams
+        total_stream = len(STREAMS.values()) # Total no of streams
         streams_name = ", ".join(error_list)
         message = "The account credentials supplied do not have read access for the following stream(s): {}."\
             "The data for the mentioned streams will not be collected if selected due to a lack of 'read' permission.".format(streams_name)
-        if len(error_list) == total_stream:
-            # If any one of stream does not have read permission then raise error.
-            raise ZendeskForbiddenError(message)
-        else:
+        if len(error_list) != total_stream:
             # If atleast one stream have read permission then just print warning message for all streams
             # which does not have read permission
             LOGGER.warning(message)
+        else:
+            # If any one of stream does not have read permission then raise error.
+            raise ZendeskForbiddenError(message)
 
 
     return streams

--- a/tap_zendesk/discover.py
+++ b/tap_zendesk/discover.py
@@ -58,10 +58,18 @@ def discover_streams(client, config):
         streams.append({'stream': stream.name, 'tap_stream_id': stream.name, 'schema': schema, 'metadata': stream.load_metadata()})
 
     if error_list:
+
+        total_stream = len(STREAMS.values()) # Total no od streams
         streams_name = ", ".join(error_list)
-        message = "HTTP-error-code: 403, Error: You are missing the following required scopes: read. "\
-                    "The account credentials supplied do not have read access for the following stream(s):  {}".format(streams_name)
-        raise ZendeskForbiddenError(message)
+        message = "The account credentials supplied do not have read access for the following stream(s): {}."\
+            "The data for the mentioned streams will not be collected if selected due to a lack of 'read' permission.".format(streams_name)
+        if len(error_list) == total_stream:
+            # If any one of stream does not have read permission then raise error.
+            raise ZendeskForbiddenError(message)
+        else:
+            # If atleast one stream have read permission then just print warning message for all streams
+            # which does not have read permission
+            LOGGER.warning(message)
 
 
     return streams

--- a/test/unittests/test_discovery_mode.py
+++ b/test/unittests/test_discovery_mode.py
@@ -64,10 +64,10 @@ class TestDiscovery(unittest.TestCase):
         self.assertEqual(expected_call_count, actual_call_count)
 
         # Verifying the logger message
-        mock_logger.assert_called_with("The account credentials supplied do not have read access for the following "\
-            "stream(s): groups, users, organizations, ticket_audits, ticket_comments, ticket_fields, ticket_forms, "\
-            "group_memberships, macros, satisfaction_ratings, tags, ticket_metrics.The data for the mentioned streams "\
-            "will not be collected if selected due to a lack of 'read' permission.")
+        mock_logger.assert_called_with("The account credentials supplied do not have 'read' access to the following stream(s): "\
+            "groups, users, organizations, ticket_audits, ticket_comments, ticket_fields, ticket_forms, group_memberships, macros, "\
+            "satisfaction_ratings, tags, ticket_metrics. The data for these streams would not be collected due to lack of required "\
+            "permission.")
 
     @patch("tap_zendesk.discover.LOGGER.warning")
     @patch('tap_zendesk.streams.Organizations.check_access',side_effect=zenpy.lib.exception.APIException(ACCSESS_TOKEN_ERROR))
@@ -106,12 +106,12 @@ class TestDiscovery(unittest.TestCase):
         expected_call_count = 10
         actual_call_count = mock_get.call_count
         self.assertEqual(expected_call_count, actual_call_count)
-
+    
         # Verifying the logger message
-        mock_logger.assert_called_with("The account credentials supplied do not have read access for the following stream(s): "\
-            "groups, users, organizations, ticket_audits, ticket_comments, ticket_fields, ticket_forms, group_memberships, "\
-            "macros, satisfaction_ratings, tags, ticket_metrics, sla_policies.The data for the mentioned streams will not be "\
-            "collected if selected due to a lack of 'read' permission.")
+        mock_logger.assert_called_with("The account credentials supplied do not have 'read' access to the following stream(s): "\
+            "groups, users, organizations, ticket_audits, ticket_comments, ticket_fields, ticket_forms, group_memberships, macros, "\
+            "satisfaction_ratings, tags, ticket_metrics, sla_policies. The data for these streams would not be collected due to "\
+            "lack of required permission.")
 
     @patch("tap_zendesk.discover.LOGGER.warning")
     @patch('tap_zendesk.streams.Organizations.check_access',side_effect=zenpy.lib.exception.APIException(API_TOKEN_ERROR))
@@ -152,9 +152,9 @@ class TestDiscovery(unittest.TestCase):
         self.assertEqual(expected_call_count, actual_call_count)
 
         # Verifying the logger message
-        mock_logger.assert_called_with("The account credentials supplied do not have read access for the following stream(s): "\
+        mock_logger.assert_called_with("The account credentials supplied do not have 'read' access to the following stream(s): "\
             "tickets, groups, users, organizations, ticket_fields, ticket_forms, group_memberships, macros, satisfaction_ratings, "\
-            "tags.The data for the mentioned streams will not be collected if selected due to a lack of 'read' permission.")
+            "tags. The data for these streams would not be collected due to lack of required permission.")
         
     @patch('tap_zendesk.streams.Organizations.check_access',side_effect=zenpy.lib.exception.APIException(ACCSESS_TOKEN_ERROR))
     @patch('tap_zendesk.streams.Users.check_access',side_effect=zenpy.lib.exception.APIException(ACCSESS_TOKEN_ERROR))
@@ -302,9 +302,8 @@ class TestDiscovery(unittest.TestCase):
         try:
             responses = discover.discover_streams('dummy_client', {'subdomain': 'arp', 'access_token': 'dummy_token', 'start_date':START_DATE})
         except http.ZendeskForbiddenError as e:
-            expected_message = "The account credentials supplied do not have read access for the following stream(s): "\
-                "tickets, groups, users, organizations, ticket_audits, ticket_comments, ticket_fields, ticket_forms, "\
-                "group_memberships, macros, satisfaction_ratings, tags, ticket_metrics, sla_policies.The data for the "\
-                "mentioned streams will not be collected if selected due to a lack of 'read' permission."
-            # Verifying the message formed for the custom exception
+            expected_message = "HTTP-error-code: 403, Error: You are missing the following required scopes: read. The account credentials "\
+                "supplied do not have read access for the following stream(s):  tickets, groups, users, organizations, ticket_audits, "\
+                "ticket_comments, ticket_fields, ticket_forms, group_memberships, macros, satisfaction_ratings, tags, ticket_metrics, sla_policies"
+            # # Verifying the message formed for the custom exception
             self.assertEqual(str(e), expected_message)

--- a/test/unittests/test_discovery_mode.py
+++ b/test/unittests/test_discovery_mode.py
@@ -302,8 +302,7 @@ class TestDiscovery(unittest.TestCase):
         try:
             responses = discover.discover_streams('dummy_client', {'subdomain': 'arp', 'access_token': 'dummy_token', 'start_date':START_DATE})
         except http.ZendeskForbiddenError as e:
-            expected_message = "HTTP-error-code: 403, Error: You are missing the following required scopes: read. The account credentials "\
-                "supplied do not have read access for the following stream(s):  tickets, groups, users, organizations, ticket_audits, "\
-                "ticket_comments, ticket_fields, ticket_forms, group_memberships, macros, satisfaction_ratings, tags, ticket_metrics, sla_policies"
+            expected_message = "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "\
+            "of streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
             # # Verifying the message formed for the custom exception
             self.assertEqual(str(e), expected_message)

--- a/test/unittests/test_discovery_mode.py
+++ b/test/unittests/test_discovery_mode.py
@@ -59,6 +59,9 @@ class TestDiscovery(unittest.TestCase):
 
         '''
         discover.discover_streams('dummy_client', {'subdomain': 'arp', 'access_token': 'dummy_token', 'start_date':START_DATE})
+        expected_call_count = 10
+        actual_call_count = mock_get.call_count
+        self.assertEqual(expected_call_count, actual_call_count)
 
         # Verifying the logger message
         mock_logger.assert_called_with("The account credentials supplied do not have read access for the following "\
@@ -100,6 +103,10 @@ class TestDiscovery(unittest.TestCase):
         '''
         discover.discover_streams('dummy_client', {'subdomain': 'arp', 'access_token': 'dummy_token', 'start_date':START_DATE})
 
+        expected_call_count = 10
+        actual_call_count = mock_get.call_count
+        self.assertEqual(expected_call_count, actual_call_count)
+
         # Verifying the logger message
         mock_logger.assert_called_with("The account credentials supplied do not have read access for the following stream(s): "\
             "groups, users, organizations, ticket_audits, ticket_comments, ticket_fields, ticket_forms, group_memberships, "\
@@ -140,6 +147,10 @@ class TestDiscovery(unittest.TestCase):
         '''
 
         responses = discover.discover_streams('dummy_client', {'subdomain': 'arp', 'access_token': 'dummy_token', 'start_date':START_DATE})
+        expected_call_count = 10
+        actual_call_count = mock_get.call_count
+        self.assertEqual(expected_call_count, actual_call_count)
+
         # Verifying the logger message
         mock_logger.assert_called_with("The account credentials supplied do not have read access for the following stream(s): "\
             "tickets, groups, users, organizations, ticket_fields, ticket_forms, group_memberships, macros, satisfaction_ratings, "\


### PR DESCRIPTION
# Description of change
- Revert backed API access change in discover mode.
- Now, if at least one stream have read permission then tap just print warning message for all streams which does not have read permission
- If any one of stream does not have read permission then raise error.

# Manual QA steps
 - Create access token with limited scope and verify tap behaviour.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
