### PR TITLE
Bump version 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 1.8.0
+  * Reverted back API access change login during discover mode [90](https://github.com/singer-io/tap-zendesk/pull/90)
 ## 1.7.0
   * Removed Buffer System [77](https://github.com/singer-io/tap-zendesk/pull/77)
   * Check API access in discovery mode [74](https://github.com/singer-io/tap-zendesk/pull/74)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='1.7.0',
+      version='1.8.0',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
Bump version for zendesk to take care of API Access logic change

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
