### PR TITLE
Backoff for all 5xx errors

### DIFF
--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -137,7 +137,7 @@ def raise_for_error(response):
         raise exc(message, response) from None
 
 @backoff.on_exception(backoff.expo,
-                      (HTTPError, ZendeskError), # Added support of backoff for all 5xx errors.
+                      (HTTPError, ZendeskError), # Added support of backoff for all unhandled status codes.
                       max_tries=10,
                       giveup=is_fatal)
 @backoff.on_exception(backoff.expo,

--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -137,7 +137,7 @@ def raise_for_error(response):
         raise exc(message, response) from None
 
 @backoff.on_exception(backoff.expo,
-                      (HTTPError, ZendeskBackoffError),
+                      (HTTPError, ZendeskError), # Added support of backoff for all 5xx errors.
                       max_tries=10,
                       giveup=is_fatal)
 @backoff.on_exception(backoff.expo,

--- a/test/unittests/test_http.py
+++ b/test/unittests/test_http.py
@@ -308,3 +308,35 @@ class TestBackoff(unittest.TestCase):
         # Verify the request retry 5 times on timeout 
         self.assertEqual(mock_get.call_count, 10)
             
+
+    @patch('requests.get',side_effect=10*[mocked_get(status_code=524, json={"key1": "val1"})])
+    def test_get_cursor_based_handles_524(self,mock_get, mock_sleep):
+        """
+        Test that the tap can handle 524 error and retry it 10 times
+        """
+        try:
+            responses = [response for response in http.get_cursor_based(url='some_url',
+                                                                    access_token='some_token', request_timeout=300)]
+        except http.ZendeskError as e:
+            expected_error_message = "HTTP-error-code: 524, Error: Unknown Error"
+            # Verify the message formed for the custom exception
+            self.assertEqual(str(e), expected_error_message)
+
+        #Verify the request retry 10 times
+        self.assertEqual(mock_get.call_count, 10)
+
+    @patch('requests.get',side_effect=10*[mocked_get(status_code=520, json={"key1": "val1"})])
+    def test_get_cursor_based_handles_520(self,mock_get, mock_sleep):
+        """
+        Test that the tap can handle 520 error and retry it 10 times
+        """
+        try:
+            responses = [response for response in http.get_cursor_based(url='some_url',
+                                                                    access_token='some_token', request_timeout=300)]
+        except http.ZendeskError as e:
+            expected_error_message = "HTTP-error-code: 520, Error: Unknown Error"
+            # Verify the message formed for the custom exception
+            self.assertEqual(str(e), expected_error_message)
+
+        #Verify the request retry 10 times
+        self.assertEqual(mock_get.call_count, 10)


### PR DESCRIPTION
# Description of change
- Added back retry mechanism for all 5xx errors.
- Added unit test cases for 524 and 520 errors.

# Manual QA steps
 - Raise Httperror with status code 524 and 520 error and verify retry.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
