### PR TITLE
Bump version 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
-
+## 1.7.2
+  * 524 and 520 error codes are taken care in this release to retry [93](https://github.com/singer-io/tap-zendesk/pull/93)
 ## 1.7.1
   * Reverted back API access change login during discover mode [90](https://github.com/singer-io/tap-zendesk/pull/90)
 ## 1.7.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='1.7.1',
+      version='1.7.2',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
This bump version is to take care of 520 and 524 Errors that were encountered in 1.7.1 release. Now we are going to try for all errors rather than specific errors as mentioned in Zendesk Documentation

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
