### PR TITLE
Bump version 1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
   * 503 error code retry is taken care in ths release [#95](https://github.com/singer-io/tap-zendesk/pull/95)
 ## 1.7.2
   * 524 and 520 error codes are taken care in this release to retry [93](https://github.com/singer-io/tap-zendesk/pull/93)
-  * 524 and 520 error codes are taken care in this release to retry [93](https://github.com/singer-io/tap-zendesk/pull/93)
 ## 1.7.1
   * Reverted back API access change login during discover mode [90](https://github.com/singer-io/tap-zendesk/pull/90)
 ## 1.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
+## 1.7.3
+  * 503 error code retry is taken care in ths release [#95](https://github.com/singer-io/tap-zendesk/pull/95)
 ## 1.7.2
+  * 524 and 520 error codes are taken care in this release to retry [93](https://github.com/singer-io/tap-zendesk/pull/93)
   * 524 and 520 error codes are taken care in this release to retry [93](https://github.com/singer-io/tap-zendesk/pull/93)
 ## 1.7.1
   * Reverted back API access change login during discover mode [90](https://github.com/singer-io/tap-zendesk/pull/90)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='1.7.2',
+      version='1.7.3',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
Found couple of transactions for a set of customers not doing retry for 503 errors. This bump version is to fix the retry for 503 errors as in the previous version of the code. As per Zendeks, 503 retries are supposed to be done only when the retry headers mentions it, but that is against the implementation of previous version of code.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
