### PR TITLE
TDL-16912 Fix pagination test failure

### DIFF
--- a/test/test_pagination.py
+++ b/test/test_pagination.py
@@ -24,7 +24,6 @@ class ZendeskPagination(ZendeskTest):
         expected_streams = self.expected_check_streams()
         expected_streams = expected_streams - {
             "satisfaction_ratings", # skip as only end user of tickets can create data
-            "tags",  # https://jira.talendforge.org/browse/TDL-16895
         }
 
         conn_id = connections.ensure_connection(self)


### PR DESCRIPTION
# Description of change
- Generated enough records to pass the pagination test.
- Removed workaround from pagination test.

**Note:** Created [TDL-16941](https://jira.talendforge.org/browse/TDL-16941) for long-term solution to create `tags` record once token with write permission updated in circle-ci.
# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
