### PR TITLE
change regression build runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ workflows:
     <<: *commit_jobs
     triggers:
       - schedule:
-          cron: "0 6 * * *"
+          cron: "0 1 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,13 +76,19 @@ workflows:
   commit: &commit_jobs
     jobs:
       - build_and_test:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
       - integration_tests:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           requires:
             - build_and_test
       - build:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           requires:
             - integration_tests
 


### PR DESCRIPTION
# Description of change
Move build time to avoid conflicts with contractors and internal teams.
6:00am  UTC -> 1:00 UTC (8:00pm EST, 6:30am IST)

Move slack notifications to new channel.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
