### PR TITLE
add backoff to the sync execution job in tests workaround ssl timeouts

### DIFF
--- a/test/base.py
+++ b/test/base.py
@@ -11,13 +11,15 @@ from tap_tester import menagerie
 from tap_tester import runner
 from tap_tester import LOGGER
 
+# BUG https://jira.talendforge.org/browse/TDL-19985
 
-def backoff_wait_times():
+
+def backoff_wait_times(): # BUG_TDL-19985
     """Create a generator of wait times as [30, 60, 120, 240, 480, ...]"""
     return backoff.expo(factor=30)
 
 
-class RetryableTapError(Exception):
+class RetryableTapError(Exception): # BUG_TDL-19985
     def __init__(self, message):
         super().__init__(message)
 
@@ -221,6 +223,7 @@ class ZendeskTest(unittest.TestCase):
         self.assertIn("handshake", tap_error_message.lower())
         self.assertIn("failure", tap_error_message.lower())
 
+    # BUG_TDL-19985
     @backoff.on_exception(backoff_wait_times,
                           RetryableTapError,
                           max_tries=3)
@@ -231,6 +234,7 @@ class ZendeskTest(unittest.TestCase):
         # verify tap and target exit codes
         exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
 
+        # BUG_TDL-19985 WORKAROUND START
         try:
             menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
         except AssertionError as err:
@@ -238,6 +242,8 @@ class ZendeskTest(unittest.TestCase):
                 LOGGER.info("*******************RETRYING SYNC DUE TO TIMEOUT ERROR*******************")
                 raise RetryableTapError(err)
             raise
+        # BUG_TDL-19985 WORKAROUND END
+
         sync_record_count = runner.examine_target_output_file(self,
                                                               conn_id,
                                                               self.expected_check_streams(),

--- a/test/base.py
+++ b/test/base.py
@@ -238,6 +238,7 @@ class ZendeskTest(unittest.TestCase):
         try:
             menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
         except AssertionError as err:
+            LOGGER.info("*******************ASSERTION ERRORR*******************")
             if self.is_ssl_handshake_error(exit_status):
                 LOGGER.info("*******************RETRYING SYNC DUE TO TIMEOUT ERROR*******************")
                 raise RetryableTapError(err)

--- a/test/base.py
+++ b/test/base.py
@@ -14,11 +14,6 @@ from tap_tester import LOGGER
 # BUG https://jira.talendforge.org/browse/TDL-19985
 
 
-def backoff_wait_times(): # BUG_TDL-19985
-    """Create a generator of wait times as [30, 60, 120, 240, 480, ...]"""
-    return backoff.expo(factor=30)
-
-
 class RetryableTapError(Exception): # BUG_TDL-19985
     def __init__(self, message):
         super().__init__(message)
@@ -230,9 +225,10 @@ class ZendeskTest(unittest.TestCase):
         return False
 
     # BUG_TDL-19985
-    @backoff.on_exception(backoff_wait_times,
+    @backoff.on_exception(backoff.expo,
                           RetryableTapError,
-                          max_tries=3)
+                          max_tries=2,
+                          factor=30)
     def run_and_verify_sync(self, conn_id):
 
         sync_job_name = runner.run_sync_mode(self, conn_id)


### PR DESCRIPTION
# Description of change
Fix tap-tester test stability with a workaround for the consistent Connection Pool Errors from zendesk API.
Implemented backoff wrapper on the method call to execute sync, will retry if the HTTPSConnectionPool error is returned int he tap_error_message. 

# Manual QA steps
 - Ran code with debugger and overrode the the exit status with one from a failed build job to ensure retry logic catches the erorr.
 
# Risks
 - There is a potential that this could hide bugs or other test stability issues.
 
# Rollback steps
 - revert this branch
