### PR TITLE
save test artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,8 @@ jobs:
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
+            mkdir /tmp/${CIRCLE_PROJECT_REPONAME}
+            export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install 'zenpy==2.0.24'
             circleci tests glob "test/*.py" | circleci tests split > ./tests-to-run
@@ -70,6 +72,8 @@ jobs:
             fi
       - slack/notify-on-failure:
           only_for_branches: master
+      - store_artifacts:
+          path: /tmp/tap-zendesk
 
 workflows:
   version: 2

--- a/test/test_all_streams.py
+++ b/test/test_all_streams.py
@@ -69,17 +69,10 @@ class ZendeskAllStreams(ZendeskTest):
         menagerie.set_state(conn_id, {})
 
         # Run a sync job using orchestrator
-        sync_job_name = runner.run_sync_mode(self, conn_id)
-
-        # Verify tap and target exit codes
-        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
-        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+        # Verify exit status is 0 and verify rows were synced
+        _ = self.run_and_verify_sync(conn_id)
 
         # Verify actual rows were synced
-        record_count_by_stream = runner.examine_target_output_file(self, conn_id, self.expected_sync_streams(), self.expected_pks())
-        replicated_row_count =  reduce(lambda accum,c : accum + c, record_count_by_stream.values())
-        self.assertGreater(replicated_row_count, 0, msg="failed to replicate any data: {}".format(record_count_by_stream))
-        print("total replicated row count: {}".format(replicated_row_count))
 
         # Ensure all records have a value for PK(s)
         records = runner.get_records_from_target_output()

--- a/test/test_bookmarks.py
+++ b/test/test_bookmarks.py
@@ -74,17 +74,8 @@ class ZendeskBookmarks(ZendeskTest):
         menagerie.set_state(conn_id, {})
 
         # Run a sync job using orchestrator
-        sync_job_name = runner.run_sync_mode(self, conn_id)
-
-        # Verify tap and target exit codes
-        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
-        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
-
-        # Verify actual rows were synced
-        record_count_by_stream = runner.examine_target_output_file(self, conn_id, self.expected_sync_streams(), self.expected_pks())
-        replicated_row_count =  reduce(lambda accum,c : accum + c, record_count_by_stream.values())
-        self.assertGreater(replicated_row_count, 0, msg="failed to replicate any data: {}".format(record_count_by_stream))
-        print("total replicated row count: {}".format(replicated_row_count))
+        # Verify exit status is 0 and verify rows were synced
+        _ = self.run_and_verify_sync(conn_id)
 
         # Ensure all records have a value for PK(s)
         records = runner.get_records_from_target_output()
@@ -128,10 +119,8 @@ class ZendeskBookmarks(ZendeskTest):
         print("sleeping for 60 seconds")
         time.sleep(60)
 
-        # Run another Sync
-        sync_job_name = runner.run_sync_mode(self, conn_id)
-        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
-        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+        # Run another Sync and verify it exits succesfully
+        _ = self.run_and_verify_sync(conn_id)
 
         # Check both sets of records and make sure we have our new rows
         records = runner.get_records_from_target_output()

--- a/test/test_minimal_selection.py
+++ b/test/test_minimal_selection.py
@@ -53,17 +53,8 @@ class ZendeskMinimalSelection(ZendeskTest):
         menagerie.set_state(conn_id, {})
 
         # Run a sync job using orchestrator
-        sync_job_name = runner.run_sync_mode(self, conn_id)
-
-        # Verify tap and target exit codes
-        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
-        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
-
-        # Verify actual rows were synced
-        record_count_by_stream = runner.examine_target_output_file(self, conn_id, self.expected_sync_streams(), self.expected_pks())
-        replicated_row_count =  reduce(lambda accum,c : accum + c, record_count_by_stream.values())
-        self.assertGreater(replicated_row_count, 0, msg="failed to replicate any data: {}".format(record_count_by_stream))
-        print("total replicated row count: {}".format(replicated_row_count))
+        # Verify exit status is 0 and verify rows were synced
+        _ = self.run_and_verify_sync(conn_id)
 
         # Ensure all records are retrieving the sub set of fields
         records = runner.get_records_from_target_output()


### PR DESCRIPTION
# Description of change
Save test artifacts.
Ensure HTTPConnectionPool Error test workaround (retry on failed sync due specific error) is used in all tests.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
