### PR TITLE
add backoff for ConnectionResetError, ChunkedEncodingError and ProtocolError

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-zendesk/bin/activate
-            pylint tap_zendesk -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme,stop-iteration-return,too-many-branches,useless-import-alias,no-else-return,logging-not-lazy
+            pylint tap_zendesk -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme,stop-iteration-return,too-many-branches,useless-import-alias,no-else-return,logging-not-lazy,redefined-builtin
       - run:
           name: 'unittests'
           when: always

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -6,8 +6,8 @@ from zenpy import Zenpy
 import requests
 from requests import Session
 from requests.adapters import HTTPAdapter
-from urllib3.exceptions import ProtocolError
 from requests.exceptions import Timeout, ChunkedEncodingError
+from urllib3.exceptions import ProtocolError
 import singer
 from singer import metadata, metrics as singer_metrics
 import backoff

--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -2,7 +2,7 @@ from time import sleep
 import backoff
 import requests
 import singer
-from requests.exceptions import Timeout, HTTPError, ChunkedEncodingError, ConnectionError
+from requests.exceptions import Timeout, HTTPError, ChunkedEncodingError
 from urllib3.exceptions import ProtocolError
 
 

--- a/test/base.py
+++ b/test/base.py
@@ -362,7 +362,7 @@ class ZendeskTest(unittest.TestCase):
         try:
             return dt.utcfromtimestamp(int(date_value))
         except ValueError:
-            LOGGER.warning(f"cannot convert {date_value} to int ")
+            pass
 
         raise NotImplementedError(
             "Tests do not account for dates of this format: {}".format(date_value))

--- a/test/base.py
+++ b/test/base.py
@@ -355,7 +355,9 @@ class ZendeskTest(unittest.TestCase):
             try:
                 date_stripped = dt.strptime(date_value, date_format)
                 return date_stripped
-            except ValueError:
+            except ValueError as e:
+                if str(e) == "second must be in 0..59" and date_format == '%H%M%S%f':
+                    return dt.fromtimestamp(int(date_value))
                 continue
 
         raise NotImplementedError(

--- a/test/base.py
+++ b/test/base.py
@@ -348,17 +348,21 @@ class ZendeskTest(unittest.TestCase):
             "%Y-%m-%dT%H:%M:%SZ",
             "%Y-%m-%dT%H:%M:%S.%f+00:00",
             "%Y-%m-%dT%H:%M:%S+00:00",
-            "%Y-%m-%d",
-            "%H%M%S%f"
+            "%Y-%m-%d"
         }
         for date_format in date_formats:
             try:
                 date_stripped = dt.strptime(date_value, date_format)
                 return date_stripped
-            except ValueError as e:
-                if str(e) == "second must be in 0..59" and date_format == '%H%M%S%f':
-                    return dt.fromtimestamp(int(date_value))
+            except ValueError:
                 continue
+
+        # Below try-catch block is used to convert the epoch to datetime value
+        # if the date_value doesn't fall under any of date formats mentioned above.
+        try:
+            return dt.utcfromtimestamp(int(date_value))
+        except ValueError:
+            LOGGER.warning(f"cannot convert {date_value} to int ")
 
         raise NotImplementedError(
             "Tests do not account for dates of this format: {}".format(date_value))

--- a/test/unittests/test_http.py
+++ b/test/unittests/test_http.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, Mock, patch
 from tap_zendesk import http, streams
 import requests
 from urllib3.exceptions import ProtocolError
-from requests.exceptions import ChunkedEncodingError, ConnectionError
+from requests.exceptions import ChunkedEncodingError
 
 import zenpy
 


### PR DESCRIPTION
# Description of change
Duplicates #131 for all the connections using 1.x versions
Adds backoff for ChunkedEncodingError, ProtocolError and ConnectionResetError

```
- urllib3.exceptions.ProtocolError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
- requests.exceptions.ChunkedEncodingError: ("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
```

# Manual QA steps
 - 
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
