### PR TITLE
[TDL-22930] API Token support for Zendesk

### DIFF
--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -1,5 +1,6 @@
 from time import sleep
 import backoff
+import base64
 import requests
 import singer
 from requests.exceptions import Timeout, HTTPError, ChunkedEncodingError, ConnectionError

--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -114,6 +114,15 @@ def is_fatal(exception):
 
     return 400 <=status_code < 500
 
+def update_authorization_headers(config, headers):
+    if "access_token" in config:
+        headers['Authorization'] = 'Bearer {}'.format(config["access_token"])
+    else:
+        basic_auth_string = '{}/token:{}'.format(config["email"], config["api_token"])
+        encoded_basic_auth = base64.b64encode(basic_auth_string.encode("utf-8")).decode("utf-8")
+        headers['Authorization'] = 'Basic {}'.format(encoded_basic_auth)
+    return headers
+
 def raise_for_error(response):
     """ Error handling method which throws custom error. Class for each error defined above which extends `ZendeskError`.
     This method map the status code with `ERROR_CODE_EXCEPTION_MAPPING` dictionary and accordingly raise the error.

--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -149,14 +149,7 @@ def call_api(url, request_timeout, params, headers):
     raise_for_error(response)
     return response
 
-def get_cursor_based(url, access_token, request_timeout, cursor=None, **kwargs):
-    headers = {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-        'Authorization': 'Bearer {}'.format(access_token),
-        **kwargs.get('headers', {})
-    }
-
+def get_cursor_based(url, headers, request_timeout, cursor=None, **kwargs):
     params = {
         'page[size]': 100,
         **kwargs.get('params', {})
@@ -181,14 +174,7 @@ def get_cursor_based(url, access_token, request_timeout, cursor=None, **kwargs):
         yield response_json
         has_more = response_json['meta']['has_more']
 
-def get_offset_based(url, access_token, request_timeout, **kwargs):
-    headers = {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-        'Authorization': 'Bearer {}'.format(access_token),
-        **kwargs.get('headers', {})
-    }
-
+def get_offset_based(url, headers, request_timeout, **kwargs):
     params = {
         'per_page': 100,
         **kwargs.get('params', {})
@@ -208,13 +194,7 @@ def get_offset_based(url, access_token, request_timeout, **kwargs):
         yield response_json
         next_url = response_json.get('next_page')
 
-def get_incremental_export(url, access_token, request_timeout, start_time):
-    headers = {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-        'Authorization': 'Bearer {}'.format(access_token),
-    }
-
+def get_incremental_export(url, headers, request_timeout, start_time):
     params = {'start_time': start_time}
 
     if not isinstance(start_time, int):

--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -1,6 +1,6 @@
 from time import sleep
-import backoff
 import base64
+import backoff
 import requests
 import singer
 from requests.exceptions import Timeout, HTTPError, ChunkedEncodingError, ConnectionError

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -32,15 +32,6 @@ CUSTOM_TYPES = {
     'checkbox': 'boolean',
 }
 
-def update_authorization_headers(config, headers):
-    if "access_token" in config:
-        headers['Authorization'] = 'Bearer {}'.format(config["access_token"])
-    else:
-        basic_auth_string = '{}/token:{}'.format(config["email"], config["api_token"])
-        encoded_basic_auth = base64.b64encode(basic_auth_string.encode("utf-8")).decode("utf-8")
-        headers['Authorization'] = 'Basic {}'.format(encoded_basic_auth)
-    return headers
-
 
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
@@ -133,7 +124,7 @@ class Stream():
         Check whether the permission was given to access stream resources or not.
         '''
         url = self.endpoint.format(self.config['subdomain'])
-        headers = update_authorization_headers(self.config, HEADERS)
+        headers = http.update_authorization_headers(self.config, HEADERS)
 
         http.call_api(url, self.request_timeout, params={'per_page': 1}, headers=headers)
 
@@ -151,7 +142,7 @@ class CursorBasedStream(Stream):
             'Accept': 'application/json',
             **kwargs.get('headers', {})
         }
-        headers = update_authorization_headers(self.config, headers)
+        headers = http.update_authorization_headers(self.config, headers)
         # Pass `request_timeout` parameter
         for page in http.get_cursor_based(url, headers, self.request_timeout, **kwargs):
             yield from page[self.item_key]
@@ -165,7 +156,7 @@ class CursorBasedExportStream(Stream):
         Retrieve objects from the incremental exports endpoint using cursor based pagination
         '''
         url = self.endpoint.format(self.config['subdomain'])
-        headers = update_authorization_headers(self.config, HEADERS)
+        headers = http.update_authorization_headers(self.config, HEADERS)
         # Pass `request_timeout` parameter
         for page in http.get_incremental_export(url, headers, self.request_timeout, start_time):
             yield from page[self.item_key]
@@ -356,7 +347,7 @@ class Tickets(CursorBasedExportStream):
         url = self.endpoint.format(self.config['subdomain'])
         # Convert start_date parameter to timestamp to pass with request param
         start_time = datetime.datetime.strptime(self.config['start_date'], START_DATE_FORMAT).timestamp()
-        headers = update_authorization_headers(self.config, HEADERS)
+        headers = http.update_authorization_headers(self.config, HEADERS)
 
         http.call_api(url, self.request_timeout, params={'start_time': start_time, 'per_page': 1}, headers=headers)
 
@@ -370,7 +361,7 @@ class TicketAudits(Stream):
 
     def get_objects(self, ticket_id):
         url = self.endpoint.format(self.config['subdomain'], ticket_id)
-        headers = update_authorization_headers(self.config, HEADERS)
+        headers = http.update_authorization_headers(self.config, HEADERS)
         # Pass `request_timeout` parameter
         pages = http.get_offset_based(url, headers, self.request_timeout)
         for page in pages:
@@ -389,7 +380,7 @@ class TicketAudits(Stream):
         '''
 
         url = self.endpoint.format(self.config['subdomain'], '1')
-        headers = update_authorization_headers(self.config, HEADERS)
+        headers = http.update_authorization_headers(self.config, HEADERS)
         try:
             http.call_api(url, self.request_timeout, params={'per_page': 1}, headers=headers)
         except http.ZendeskNotFoundError:
@@ -406,7 +397,7 @@ class TicketMetrics(CursorBasedStream):
     def sync(self, ticket_id):
         # Only 1 ticket metric per ticket
         url = self.endpoint.format(self.config['subdomain'], ticket_id)
-        headers = update_authorization_headers(self.config, HEADERS)
+        headers = http.update_authorization_headers(self.config, HEADERS)
         # Pass `request_timeout`
         pages = http.get_offset_based(url, headers, self.request_timeout)
         for page in pages:
@@ -419,7 +410,7 @@ class TicketMetrics(CursorBasedStream):
         Check whether the permission was given to access stream resources or not.
         '''
         url = self.endpoint.format(self.config['subdomain'], '1')
-        headers = update_authorization_headers(self.config, HEADERS)
+        headers = http.update_authorization_headers(self.config, HEADERS)
         try:
             http.call_api(url, self.request_timeout, params={'per_page': 1}, headers=headers)
         except http.ZendeskNotFoundError:
@@ -463,7 +454,7 @@ class TicketComments(Stream):
 
     def get_objects(self, ticket_id):
         url = self.endpoint.format(self.config['subdomain'], ticket_id)
-        headers = update_authorization_headers(self.config, HEADERS)
+        headers = http.update_authorization_headers(self.config, HEADERS)
         # Pass `request_timeout` parameter
         pages = http.get_offset_based(url, headers, self.request_timeout)
 
@@ -482,7 +473,7 @@ class TicketComments(Stream):
         Check whether the permission was given to access stream resources or not.
         '''
         url = self.endpoint.format(self.config['subdomain'], '1')
-        headers = update_authorization_headers(self.config, HEADERS)
+        headers = http.update_authorization_headers(self.config, HEADERS)
         try:
             http.call_api(url, self.request_timeout, params={'per_page': 1}, headers=headers)
         except http.ZendeskNotFoundError:

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -1,7 +1,6 @@
 import os
 import json
 import datetime
-import base64
 import pytz
 import zenpy
 import singer

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -1,6 +1,7 @@
 import os
 import json
 import datetime
+import base64
 import pytz
 import zenpy
 import singer
@@ -9,7 +10,6 @@ from singer import utils
 from singer.metrics import Point
 from tap_zendesk import metrics as zendesk_metrics
 from tap_zendesk import http
-import base64
 
 
 LOGGER = singer.get_logger()
@@ -32,7 +32,7 @@ CUSTOM_TYPES = {
     'checkbox': 'boolean',
 }
 
-def update_authorization_headers(config, headers={}):
+def update_authorization_headers(config, headers):
     if "access_token" in config:
         headers['Authorization'] = 'Bearer {}'.format(config["access_token"])
     else:

--- a/test/unittests/test_http.py
+++ b/test/unittests/test_http.py
@@ -74,11 +74,12 @@ class TestBackoff(unittest.TestCase):
         "requests.get", side_effect=[mocked_get(status_code=200, json=SINGLE_RESPONSE)]
     )
     def test_get_cursor_based_gets_one_page(self, mock_get, mock_sleep):
+        headers = {}
         responses = [
             response
             for response in http.get_cursor_based(
                 url="some_url",
-                access_token="some_token",
+                headers=headers,
                 request_timeout=REQUEST_TIMEOUT,
             )
         ]
@@ -97,11 +98,12 @@ class TestBackoff(unittest.TestCase):
         ],
     )
     def test_get_cursor_based_can_paginate(self, mock_get, mock_sleep):
+        headers={}
         responses = [
             response
             for response in http.get_cursor_based(
                 url="some_url",
-                access_token="some_token",
+                headers=headers,
                 request_timeout=REQUEST_TIMEOUT,
             )
         ]
@@ -135,11 +137,12 @@ class TestBackoff(unittest.TestCase):
         - requests uses a case insensitive dict for the `headers`
         - can handle either a string or an integer for the retry header
         """
+        headers={}
         responses = [
             response
             for response in http.get_cursor_based(
                 url="some_url",
-                access_token="some_token",
+                headers=headers,
                 request_timeout=REQUEST_TIMEOUT,
             )
         ]
@@ -155,10 +158,11 @@ class TestBackoff(unittest.TestCase):
     )
     def test_get_cursor_based_handles_400(self, mock_get, mock_sleep):
         try:
+            headers={}
             responses = [
                 response
                 for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
+                    url="some_url", headers=headers, request_timeout=300
                 )
             ]
 
@@ -180,10 +184,11 @@ class TestBackoff(unittest.TestCase):
     )
     def test_get_cursor_based_handles_400_api_error_message(self, mock_get, mock_sleep):
         try:
+            headers={}
             responses = [
                 response
                 for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
+                    url="some_url", headers=headers, request_timeout=300
                 )
             ]
 
@@ -202,10 +207,11 @@ class TestBackoff(unittest.TestCase):
     )
     def test_get_cursor_based_handles_401(self, mock_get, mock_sleep):
         try:
+            headers={}
             responses = [
                 response
                 for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
+                    url="some_url", headers=headers, request_timeout=300
                 )
             ]
         except http.ZendeskUnauthorizedError as e:
@@ -224,10 +230,11 @@ class TestBackoff(unittest.TestCase):
     )
     def test_get_cursor_based_handles_404(self, mock_get, mock_sleep):
         try:
+            headers={}
             responses = [
                 response
                 for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
+                    url="some_url", headers=headers, request_timeout=300
                 )
             ]
         except http.ZendeskNotFoundError as e:
@@ -245,10 +252,11 @@ class TestBackoff(unittest.TestCase):
         """
 
         with self.assertRaises(http.ZendeskConflictError) as e:
+            headers={}
             responses = [
                 response
                 for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
+                    url="some_url", headers=headers, request_timeout=300
                 )
             ]
             expected_error_message = "HTTP-error-code: 409, Error: The API request cannot be completed because the requested operation would conflict with an existing item."
@@ -262,10 +270,11 @@ class TestBackoff(unittest.TestCase):
     )
     def test_get_cursor_based_handles_422(self, mock_get, mock_sleep):
         try:
+            headers={}
             responses = [
                 response
                 for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
+                    url="some_url", headers=headers, request_timeout=300
                 )
             ]
         except http.ZendeskUnprocessableEntityError as e:
@@ -285,10 +294,11 @@ class TestBackoff(unittest.TestCase):
         Test that the tap can handle 500 error and retry it 10 times
         """
         try:
+            headers={}
             responses = [
                 response
                 for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
+                    url="some_url", headers=headers, request_timeout=300
                 )
             ]
         except http.ZendeskInternalServerError as e:
@@ -311,10 +321,11 @@ class TestBackoff(unittest.TestCase):
         Test that the tap can handle 501 error and retry it 10 times
         """
         try:
+            headers={}
             responses = [
                 response
                 for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
+                    url="some_url", headers=headers, request_timeout=300
                 )
             ]
         except http.ZendeskNotImplementedError as e:
@@ -334,10 +345,11 @@ class TestBackoff(unittest.TestCase):
         Test that the tap can handle 502 error and retry it 10 times
         """
         try:
+            headers={}
             responses = [
                 response
                 for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
+                    url="some_url", headers=headers, request_timeout=300
                 )
             ]
         except http.ZendeskBadGatewayError as e:
@@ -357,10 +369,11 @@ class TestBackoff(unittest.TestCase):
 
         mock_get.side_effect = [fake_response]
         try:
+            headers={}
             responses = [
                 response
                 for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
+                    url="some_url", headers=headers, request_timeout=300
                 )
             ]
         except http.ZendeskError as e:
@@ -420,10 +433,11 @@ class TestBackoff(unittest.TestCase):
         Test that the tap can handle 524 error and retry it 10 times
         """
         try:
+            headers={}
             responses = [
                 response
                 for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
+                    url="some_url", headers=headers, request_timeout=300
                 )
             ]
         except http.ZendeskError as e:
@@ -443,10 +457,11 @@ class TestBackoff(unittest.TestCase):
         Test that the tap can handle 520 error and retry it 10 times
         """
         try:
+            headers={}
             responses = [
                 response
                 for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
+                    url="some_url", headers=headers, request_timeout=300
                 )
             ]
         except http.ZendeskError as e:
@@ -466,10 +481,11 @@ class TestBackoff(unittest.TestCase):
         Test that the tap can handle 503 error and retry it 10 times
         """
         try:
+            headers={}
             responses = [
                 response
                 for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
+                    url="some_url", headers=headers, request_timeout=300
                 )
             ]
         except http.ZendeskServiceUnavailableError as e:

--- a/test/unittests/test_request_timeout.py
+++ b/test/unittests/test_request_timeout.py
@@ -57,8 +57,9 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
         """
 
         try:
+            headers={}
             responses = [response for response in http.get_cursor_based(url='some_url',
-                                                                    access_token='some_token', request_timeout=REQUEST_TIMEOUT)]
+                                                                    headers=headers, request_timeout=REQUEST_TIMEOUT)]
         except requests.exceptions.Timeout as e:
             pass
 
@@ -73,8 +74,9 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
         """
 
         try:
+            headers={}
             responses = [response for response in http.get_cursor_based(url='some_url',
-                                                                    access_token='some_token', request_timeout=REQUEST_TIMEOUT)]
+                                                                    headers=headers, request_timeout=REQUEST_TIMEOUT)]
         except requests.exceptions.Timeout as e:
             pass
 
@@ -87,8 +89,9 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
         """
         
         try:
+            headers={}
             responses = [response for response in http.get_offset_based(url='some_url',
-                                                                    access_token='some_token', request_timeout=REQUEST_TIMEOUT)]
+                                                                    headers=headers, request_timeout=REQUEST_TIMEOUT)]
         except requests.exceptions.Timeout as e:
             pass
 
@@ -103,8 +106,9 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
         """
 
         try:
+            headers={}
             responses = [response for response in http.get_offset_based(url='some_url',
-                                                                    access_token='some_token', request_timeout=REQUEST_TIMEOUT)]
+                                                                    headers=headers, request_timeout=REQUEST_TIMEOUT)]
         except requests.exceptions.Timeout as e:
             pass
 
@@ -117,7 +121,8 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
         """
 
         try:
-            responses = [response for response in http.get_incremental_export(url='some_url',access_token='some_token', 
+            headers={}
+            responses = [response for response in http.get_incremental_export(url='some_url', headers=headers,
                                                                               request_timeout=REQUEST_TIMEOUT, start_time= datetime.datetime.utcnow())]
         except requests.exceptions.Timeout as e:
             pass


### PR DESCRIPTION
# Description of change
1) Added update_authorization_headers() method to update headers before API calls based on
   given authorization method (access or api token) present in tap config. 



# Manual QA steps
 - Ran discover and sync and compared the changes for api_token & access_token implementation.
 
# Risks
 - Low risk
 
# Rollback steps
 - revert this branch
