### PR TITLE
Get page_size from config or use default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 2.3.0
+  * Adds configurable page size for requests [#141](https://github.com/singer-io/tap-zendesk/pull/141)
 ## 2.2.0
   * Adds Support for lookup fields [#124](https://github.com/singer-io/tap-zendesk/pull/124)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='2.2.0',
+      version='2.3.0',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',

--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -149,7 +149,7 @@ def call_api(url, request_timeout, params, headers):
     raise_for_error(response)
     return response
 
-def get_cursor_based(url, access_token, request_timeout, cursor=None, **kwargs):
+def get_cursor_based(url, access_token, request_timeout, page_size, cursor=None, **kwargs):
     headers = {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
@@ -158,7 +158,7 @@ def get_cursor_based(url, access_token, request_timeout, cursor=None, **kwargs):
     }
 
     params = {
-        'page[size]': 100,
+        'page[size]': page_size,
         **kwargs.get('params', {})
     }
 
@@ -181,7 +181,7 @@ def get_cursor_based(url, access_token, request_timeout, cursor=None, **kwargs):
         yield response_json
         has_more = response_json['meta']['has_more']
 
-def get_offset_based(url, access_token, request_timeout, **kwargs):
+def get_offset_based(url, access_token, request_timeout, page_size, **kwargs):
     headers = {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
@@ -190,7 +190,7 @@ def get_offset_based(url, access_token, request_timeout, **kwargs):
     }
 
     params = {
-        'per_page': 100,
+        'per_page': page_size,
         **kwargs.get('params', {})
     }
 

--- a/test/unittests/test_http.py
+++ b/test/unittests/test_http.py
@@ -43,6 +43,7 @@ SINGLE_RESPONSE = {"meta": {"has_more": False}}
 
 PAGINATE_RESPONSE = {"meta": {"has_more": True, "after_cursor": "some_cursor"}}
 
+PAGE_SIZE = 100
 REQUEST_TIMEOUT = 300
 
 
@@ -76,11 +77,10 @@ class TestBackoff(unittest.TestCase):
     def test_get_cursor_based_gets_one_page(self, mock_get, mock_sleep):
         responses = [
             response
-            for response in http.get_cursor_based(
-                url="some_url",
-                access_token="some_token",
-                request_timeout=REQUEST_TIMEOUT,
-            )
+            for response in http.get_cursor_based(url="some_url",
+                                                  access_token="some_token",
+                                                  request_timeout=REQUEST_TIMEOUT,
+                                                  page_size=PAGE_SIZE)
         ]
         actual_response = responses[0]
         self.assertDictEqual(SINGLE_RESPONSE, actual_response)
@@ -99,11 +99,10 @@ class TestBackoff(unittest.TestCase):
     def test_get_cursor_based_can_paginate(self, mock_get, mock_sleep):
         responses = [
             response
-            for response in http.get_cursor_based(
-                url="some_url",
-                access_token="some_token",
-                request_timeout=REQUEST_TIMEOUT,
-            )
+            for response in http.get_cursor_based(url="some_url",
+                                                  access_token="some_token",
+                                                  request_timeout=REQUEST_TIMEOUT,
+                                                  page_size=PAGE_SIZE)
         ]
 
         self.assertDictEqual({"key1": "val1", **PAGINATE_RESPONSE}, responses[0])
@@ -137,11 +136,10 @@ class TestBackoff(unittest.TestCase):
         """
         responses = [
             response
-            for response in http.get_cursor_based(
-                url="some_url",
-                access_token="some_token",
-                request_timeout=REQUEST_TIMEOUT,
-            )
+            for response in http.get_cursor_based(url="some_url",
+                                                  access_token="some_token",
+                                                  request_timeout=REQUEST_TIMEOUT,
+                                                  page_size=PAGE_SIZE)
         ]
         actual_response = responses[0]
         self.assertDictEqual({"key1": "val1", **SINGLE_RESPONSE}, actual_response)
@@ -157,9 +155,10 @@ class TestBackoff(unittest.TestCase):
         try:
             responses = [
                 response
-                for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
-                )
+                for response in http.get_cursor_based(url="some_url",
+                                                      access_token="some_token",
+                                                      request_timeout=300,
+                                                      page_size=PAGE_SIZE)
             ]
 
         except http.ZendeskBadRequestError as e:
@@ -182,9 +181,10 @@ class TestBackoff(unittest.TestCase):
         try:
             responses = [
                 response
-                for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
-                )
+                for response in http.get_cursor_based(url="some_url",
+                                                      access_token="some_token",
+                                                      request_timeout=300,
+                                                      page_size=PAGE_SIZE)
             ]
 
         except http.ZendeskBadRequestError as e:
@@ -204,9 +204,10 @@ class TestBackoff(unittest.TestCase):
         try:
             responses = [
                 response
-                for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
-                )
+                for response in http.get_cursor_based(url="some_url",
+                                                      access_token="some_token",
+                                                      request_timeout=300,
+                                                      page_size=PAGE_SIZE)
             ]
         except http.ZendeskUnauthorizedError as e:
             expected_error_message = (
@@ -226,9 +227,10 @@ class TestBackoff(unittest.TestCase):
         try:
             responses = [
                 response
-                for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
-                )
+                for response in http.get_cursor_based(url="some_url",
+                                                      access_token="some_token",
+                                                      request_timeout=300,
+                                                      page_size=PAGE_SIZE)
             ]
         except http.ZendeskNotFoundError as e:
             expected_error_message = "HTTP-error-code: 404, Error: The resource you have specified cannot be found."
@@ -247,9 +249,10 @@ class TestBackoff(unittest.TestCase):
         with self.assertRaises(http.ZendeskConflictError) as e:
             responses = [
                 response
-                for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
-                )
+                for response in http.get_cursor_based(url="some_url",
+                                                      access_token="some_token",
+                                                      request_timeout=300,
+                                                      page_size=PAGE_SIZE)
             ]
             expected_error_message = "HTTP-error-code: 409, Error: The API request cannot be completed because the requested operation would conflict with an existing item."
             self.assertEqual(str(e), expected_error_message)
@@ -264,9 +267,10 @@ class TestBackoff(unittest.TestCase):
         try:
             responses = [
                 response
-                for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
-                )
+                for response in http.get_cursor_based(url="some_url",
+                                                      access_token="some_token",
+                                                      request_timeout=300,
+                                                      page_size=PAGE_SIZE)
             ]
         except http.ZendeskUnprocessableEntityError as e:
             expected_error_message = "HTTP-error-code: 422, Error: The request content itself is not processable by the server."
@@ -287,9 +291,10 @@ class TestBackoff(unittest.TestCase):
         try:
             responses = [
                 response
-                for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
-                )
+                for response in http.get_cursor_based(url="some_url",
+                                                      access_token="some_token",
+                                                      request_timeout=300,
+                                                      page_size=PAGE_SIZE)
             ]
         except http.ZendeskInternalServerError as e:
             expected_error_message = (
@@ -313,9 +318,10 @@ class TestBackoff(unittest.TestCase):
         try:
             responses = [
                 response
-                for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
-                )
+                for response in http.get_cursor_based(url="some_url",
+                                                      access_token="some_token",
+                                                      request_timeout=300,
+                                                      page_size=PAGE_SIZE)
             ]
         except http.ZendeskNotImplementedError as e:
             expected_error_message = "HTTP-error-code: 501, Error: The server does not support the functionality required to fulfill the request."
@@ -336,9 +342,10 @@ class TestBackoff(unittest.TestCase):
         try:
             responses = [
                 response
-                for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
-                )
+                for response in http.get_cursor_based(url="some_url",
+                                                      access_token="some_token",
+                                                      request_timeout=300,
+                                                      page_size=PAGE_SIZE)
             ]
         except http.ZendeskBadGatewayError as e:
             expected_error_message = (
@@ -359,9 +366,10 @@ class TestBackoff(unittest.TestCase):
         try:
             responses = [
                 response
-                for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
-                )
+                for response in http.get_cursor_based(url="some_url",
+                                                      access_token="some_token",
+                                                      request_timeout=300,
+                                                      page_size=PAGE_SIZE)
             ]
         except http.ZendeskError as e:
             expected_error_message = "HTTP-error-code: 444, Error: Unknown Error"
@@ -422,9 +430,10 @@ class TestBackoff(unittest.TestCase):
         try:
             responses = [
                 response
-                for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
-                )
+                for response in http.get_cursor_based(url="some_url",
+                                                      access_token="some_token",
+                                                      request_timeout=300,
+                                                      page_size=PAGE_SIZE)
             ]
         except http.ZendeskError as e:
             expected_error_message = "HTTP-error-code: 524, Error: Unknown Error"
@@ -445,9 +454,10 @@ class TestBackoff(unittest.TestCase):
         try:
             responses = [
                 response
-                for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
-                )
+                for response in http.get_cursor_based(url="some_url",
+                                                      access_token="some_token",
+                                                      request_timeout=300,
+                                                      page_size=PAGE_SIZE)
             ]
         except http.ZendeskError as e:
             expected_error_message = "HTTP-error-code: 520, Error: Unknown Error"
@@ -468,9 +478,10 @@ class TestBackoff(unittest.TestCase):
         try:
             responses = [
                 response
-                for response in http.get_cursor_based(
-                    url="some_url", access_token="some_token", request_timeout=300
-                )
+                for response in http.get_cursor_based(url="some_url",
+                                                      access_token="some_token",
+                                                      request_timeout=300,
+                                                      page_size=PAGE_SIZE)
             ]
         except http.ZendeskServiceUnavailableError as e:
             expected_error_message = (

--- a/test/unittests/test_request_timeout.py
+++ b/test/unittests/test_request_timeout.py
@@ -14,6 +14,7 @@ PAGINATE_RESPONSE = {
 REQUEST_TIMEOUT = 300
 REQUEST_TIMEOUT_STR = "300"
 REQUEST_TIMEOUT_FLOAT = 300.05
+PAGE_SIZE = 100
 
 SINGLE_RESPONSE = {
     'meta': {'has_more': False}
@@ -58,7 +59,9 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
 
         try:
             responses = [response for response in http.get_cursor_based(url='some_url',
-                                                                    access_token='some_token', request_timeout=REQUEST_TIMEOUT)]
+                                                                        access_token='some_token',
+                                                                        request_timeout=REQUEST_TIMEOUT,
+                                                                        page_size=PAGE_SIZE)]
         except requests.exceptions.Timeout as e:
             pass
 
@@ -74,7 +77,9 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
 
         try:
             responses = [response for response in http.get_cursor_based(url='some_url',
-                                                                    access_token='some_token', request_timeout=REQUEST_TIMEOUT)]
+                                                                        access_token='some_token',
+                                                                        request_timeout=REQUEST_TIMEOUT,
+                                                                        page_size=PAGE_SIZE)]
         except requests.exceptions.Timeout as e:
             pass
 
@@ -88,7 +93,9 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
         
         try:
             responses = [response for response in http.get_offset_based(url='some_url',
-                                                                    access_token='some_token', request_timeout=REQUEST_TIMEOUT)]
+                                                                        access_token='some_token',
+                                                                        request_timeout=REQUEST_TIMEOUT,
+                                                                        page_size=PAGE_SIZE)]
         except requests.exceptions.Timeout as e:
             pass
 
@@ -104,7 +111,9 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
 
         try:
             responses = [response for response in http.get_offset_based(url='some_url',
-                                                                    access_token='some_token', request_timeout=REQUEST_TIMEOUT)]
+                                                                        access_token='some_token',
+                                                                        request_timeout=REQUEST_TIMEOUT,
+                                                                        page_size=PAGE_SIZE)]
         except requests.exceptions.Timeout as e:
             pass
 


### PR DESCRIPTION
# Description of change
- A page size of 100 can sometimes be too large for zendesk to handle.
- Page size is now an advanced option, with a default value of 100.
  - can be set to any integer between 1 and 1000 (inclusive)

# Manual QA steps
 - Verified adjusting page size down will lead to a successful response from Zendesk
 - Values outside of 1 - 1000 will cause the default page size (100) to be used
 
# Risks
 - Low. Only requests that were previously using page size will use the custom page size, if specified.
 
# Rollback steps
 - revert this branch
