### PR TITLE
TDL-24636 Write state more often for Users and Tickets streams

### DIFF
--- a/tap_zendesk/sync.py
+++ b/tap_zendesk/sync.py
@@ -42,6 +42,9 @@ def sync_stream(state, start_date, instance):
             #  We may find out that there exists a sync that takes too long and can never emit a bookmark
             #  but we don't know if we can guarentee the order of emitted records.
 
+            if stream.tap_stream_id in ["users","tickets"] and counter.value%100==0:
+                singer.write_state(state)
+
         if instance.replication_method == "INCREMENTAL":
             singer.write_state(state)
 


### PR DESCRIPTION
# Description of change
Ensures that we're writing state throughout the replication of these streams rather than only at the end of the stream.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
