### PR TITLE
Skip child record sync for deleted tickets

### DIFF
--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -296,6 +296,10 @@ class Tickets(CursorBasedExportStream):
             # yielding stream name with record in a tuple as it is used for obtaining only the parent records while sync
             yield (self.stream, ticket)
 
+            # Skip the child record extraction for deleted tickets
+            if ticket.get('status', '') == 'deleted':
+                continue
+
             if audits_stream.is_selected():
                 try:
                     for audit in audits_stream.sync(ticket["id"]):

--- a/test/test_automatic_fields.py
+++ b/test/test_automatic_fields.py
@@ -23,6 +23,8 @@ class ZendeskAutomaticFields(ZendeskTest):
 
         streams_to_test = self.expected_check_streams() - {"talk_phone_numbers"}
 
+        streams_to_test = {"tickets", "ticket_metrics"}
+
         conn_id = connections.ensure_connection(self)
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)


### PR DESCRIPTION
# Description of change
Support ticket [TDL-25970](https://jira.talendforge.org/browse/TDL-25970)

Deleting a ticket will also delete any ticket_audit, ticket_metric or ticket_comment records associated with that ticket.

Reference links:
- [Understanding older ticket events inresponses](https://developer.zendesk.com/documentation/ticketing/managing-tickets/using-the-incremental-export-api/#understanding-older-ticket-events-in-responses)
- [Excluding system updated tickets time based exports](https://developer.zendesk.com/documentation/ticketing/managing-tickets/using-the-incremental-export-api/#excluding-system-updated-tickets-time-based-exports)
- [Deleting-tickets](https://support.zendesk.com/hc/en-us/articles/4408883872538-Deleting-tickets)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
