### PR TITLE
TDL-26578 Fix custom field date time schema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,9 @@ setup(name='tap-zendesk',
               'ipdb',
           ],
           'test': [
-              'pylint==3.0.3',
+              'aioresponses',
               'nose2',
+              'pylint==3.0.3',
               'pytest'
           ]
       },

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -48,7 +48,7 @@ def process_custom_field(field):
     json_type = CUSTOM_TYPES.get(field.type, "string")
     field_schema = {'type': [json_type, 'null']}
     if field.type == 'date':
-        field_schema['format'] = 'datetime'
+        field_schema['format'] = 'date-time'
     if field.type == 'dropdown':
         field_schema['enum'] = [o.value for o in field.custom_field_options]
 

--- a/test/unittests/test_customfield_schema_type.py
+++ b/test/unittests/test_customfield_schema_type.py
@@ -64,7 +64,7 @@ class TestCustomFieldSchemaDiscovery(unittest.TestCase):
 
 
     def test_return_field_type_date(self):
-        expected_singer_type = {"type" : ["string", "null"], 'format': 'datetime'}
+        expected_singer_type = {"type" : ["string", "null"], 'format': 'date-time'}
         z_field = self.get_z_field_obj("field_title_date", "field_key_date", "date")
         actual_singer_type = process_custom_field(z_field)
         self.assertEqual(actual_singer_type, expected_singer_type)


### PR DESCRIPTION
# Description of change
- Changes custom `date` types to use the valid json schema format `date-time` instead of the invalid `datetime`.

# Manual QA steps
 - Verified schema produced by discovery has `date-time` format for custom firlds
 
# Risks
 - Changing the json schema format`datetime` to `date-time` may cause these fields to be treated differently downstream because `date-time` is a valid format in the [json schema spec](https://json-schema.org/understanding-json-schema/reference/string#dates-and-times).
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
