### PR TITLE
TDL-26714: Fix ratelimit error and add retry for 5xx errors

### DIFF
--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -219,7 +219,7 @@ async def raise_for_error_for_async(response):
     """
     try:
         response_json = await response.json()
-    except (ContentTypeError, ValueError) as e:
+    except (ContentTypeError, ValueError):
         # Invalid JSON response
         response_json = {}
 

--- a/tap_zendesk/http.py
+++ b/tap_zendesk/http.py
@@ -259,7 +259,6 @@ async def raise_for_error_for_async(response):
     exc = ERROR_CODE_EXCEPTION_MAPPING.get(response.status, {}).get(
         "raise_exception", DEFAULT_ERROR_OBJECT
     )
-    LOGGER.error(message)
     raise exc(message, response) from None
 
 

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -354,7 +354,7 @@ class Tickets(CursorBasedExportStream):
         start_time = datetime.datetime.strptime(self.config['start_date'], START_DATE_FORMAT).timestamp()
         HEADERS['Authorization'] = 'Bearer {}'.format(self.config["access_token"])
 
-        response = http.call_api(url, self.request_timeout, params={'start_time': start_time, 'per_page': 1}, headers=HEADERS)
+        http.call_api(url, self.request_timeout, params={'start_time': start_time, 'per_page': 1}, headers=HEADERS)
 
 
 class TicketAudits(Stream):

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -21,7 +21,7 @@ DEFAULT_PAGE_SIZE = 100
 REQUEST_TIMEOUT = 300
 CONCURRENCY_LIMIT = 20
 # Reference: https://developer.zendesk.com/api-reference/introduction/rate-limits/#endpoint-rate-limits:~:text=List%20Audits%20for,requests%20per%20minute
-AUDITS_REQUEST_PER_MINUTE=500
+AUDITS_REQUEST_PER_MINUTE=450
 START_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 HEADERS = {
     'Content-Type': 'application/json',
@@ -331,10 +331,10 @@ class Tickets(CursorBasedExportStream):
                 counter+=CONCURRENCY_LIMIT
 
                 # Check if the number of records processed in a minute has reached the limit.
-                if counter >= AUDITS_REQUEST_PER_MINUTE-CONCURRENCY_LIMIT:
+                if counter >= AUDITS_REQUEST_PER_MINUTE:
                     # Processed max number of records in a minute. Sleep for few seconds.
                     # Add 2 seconds of buffer time
-                    time.sleep(max(0, 60 - (time.time() - start_time)+2))
+                    time.sleep(max(0, 60 - (time.time() - start_time)+5))
                     start_time = time.time()
                     counter = 0
 

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -313,6 +313,10 @@ class Tickets(CursorBasedExportStream):
                 metrics_stream.count+=1
                 yield (metrics_stream.stream, ticket["metric_set"])
 
+            # Skip deleted tickets because they don't have audits or comments
+            if ticket.get('status') == 'deleted':
+                continue
+
             # Check if the number of ticket IDs has reached the batch size.
             ticket_ids.append(ticket["id"])
             if len(ticket_ids) >= CONCURRENCY_LIMIT:
@@ -334,7 +338,7 @@ class Tickets(CursorBasedExportStream):
                 if counter >= AUDITS_REQUEST_PER_MINUTE:
                     # Processed max number of records in a minute. Sleep for few seconds.
                     # Add 2 seconds of buffer time
-                    time.sleep(max(0, 60 - (time.time() - start_time)+5))
+                    time.sleep(max(0, 60 - (time.time() - start_time)+2))
                     start_time = time.time()
                     counter = 0
 

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -337,10 +337,10 @@ class Tickets(CursorBasedExportStream):
                 if counter >= AUDITS_REQUEST_PER_MINUTE:
                     # Calculate elapsed time
                     elapsed_time = time.time() - start_time
-                    
+
                     # Calculate remaining time until the next minute, plus buffer of 2 more seconds
                     remaining_time = max(0, 60 - elapsed_time + 2)
-                    
+
                     # Sleep for the calculated time
                     time.sleep(remaining_time)
                     start_time = time.time()

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -18,7 +18,7 @@ KEY_PROPERTIES = ['id']
 
 DEFAULT_PAGE_SIZE = 100
 REQUEST_TIMEOUT = 300
-DEFAULT_BATCH_SIZE = 700
+DEFAULT_BATCH_SIZE = 20
 START_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 HEADERS = {
     'Content-Type': 'application/json',
@@ -276,9 +276,6 @@ class Tickets(CursorBasedExportStream):
         # https://developer.zendesk.com/documentation/ticketing/using-the-zendesk-api/side_loading/#supported-endpoints
         tickets = self.get_objects(bookmark, side_load='metric_sets')
 
-        # Run this method to set batch size to fetch ticket audits and comments records in async way
-        self.check_access()
-
         audits_stream = TicketAudits(self.client, self.config)
         metrics_stream = TicketMetrics(self.client, self.config)
         comments_stream = TicketComments(self.client, self.config)
@@ -358,10 +355,6 @@ class Tickets(CursorBasedExportStream):
         HEADERS['Authorization'] = 'Bearer {}'.format(self.config["access_token"])
 
         response = http.call_api(url, self.request_timeout, params={'start_time': start_time, 'per_page': 1}, headers=HEADERS)
-
-        # Rate limit are varies according to the zendesk account. So, we need to set the batch size dynamically.
-        # https://developer.zendesk.com/api-reference/introduction/rate-limits/
-        self.batch_size = int(response.headers.get('x-rate-limit', DEFAULT_BATCH_SIZE))
 
 
 class TicketAudits(Stream):

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -21,7 +21,7 @@ DEFAULT_PAGE_SIZE = 100
 REQUEST_TIMEOUT = 300
 CONCURRENCY_LIMIT = 20
 # Reference: https://developer.zendesk.com/api-reference/introduction/rate-limits/#endpoint-rate-limits:~:text=List%20Audits%20for,requests%20per%20minute
-AUDITS_REQUEST_PER_MINUTE=450
+AUDITS_REQUEST_PER_MINUTE = 450
 START_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 HEADERS = {
     'Content-Type': 'application/json',
@@ -331,13 +331,18 @@ class Tickets(CursorBasedExportStream):
                 ticket_ids = []
                 # Write state after processing the batch.
                 singer.write_state(state)
-                counter+=CONCURRENCY_LIMIT
+                counter += CONCURRENCY_LIMIT
 
                 # Check if the number of records processed in a minute has reached the limit.
                 if counter >= AUDITS_REQUEST_PER_MINUTE:
-                    # Processed max number of records in a minute. Sleep for few seconds.
-                    # Add 2 seconds of buffer time
-                    time.sleep(max(0, 60 - (time.time() - start_time)+2))
+                    # Calculate elapsed time
+                    elapsed_time = time.time() - start_time
+                    
+                    # Calculate remaining time until the next minute, plus buffer of 2 more seconds
+                    remaining_time = max(0, 60 - elapsed_time + 2)
+                    
+                    # Sleep for the calculated time
+                    time.sleep(remaining_time)
                     start_time = time.time()
                     counter = 0
 

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -18,7 +18,7 @@ KEY_PROPERTIES = ['id']
 
 DEFAULT_PAGE_SIZE = 100
 REQUEST_TIMEOUT = 300
-DEFAULT_BATCH_SIZE = 20
+CONCURRENCY_LIMIT = 20
 START_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 HEADERS = {
     'Content-Type': 'application/json',
@@ -266,7 +266,7 @@ class Tickets(CursorBasedExportStream):
     replication_key = "generated_timestamp"
     item_key = "tickets"
     endpoint = "https://{}.zendesk.com/api/v2/incremental/tickets/cursor.json"
-    batch_size = DEFAULT_BATCH_SIZE
+    concurrency_limit = CONCURRENCY_LIMIT
 
     def sync(self, state): #pylint: disable=too-many-statements
 
@@ -311,7 +311,7 @@ class Tickets(CursorBasedExportStream):
 
             # Check if the number of ticket IDs has reached the batch size.
             ticket_ids.append(ticket["id"])
-            if len(ticket_ids) >= self.batch_size:
+            if len(ticket_ids) >= self.concurrency_limit:
                 # Process audits and comments in batches
                 records = self.sync_ticket_audits_and_comments(
                     comments_stream, audits_stream, ticket_ids)

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -307,15 +307,14 @@ class Tickets(CursorBasedExportStream):
             # yielding stream name with record in a tuple as it is used for obtaining only the parent records while sync
             yield (self.stream, ticket)
 
+            # Skip deleted tickets because they don't have audits or comments
+            if ticket.get('status') == 'deleted':
+                continue
 
             if metrics_stream.is_selected() and ticket.get('metric_set'):
                 zendesk_metrics.capture('ticket_metric')
                 metrics_stream.count+=1
                 yield (metrics_stream.stream, ticket["metric_set"])
-
-            # Skip deleted tickets because they don't have audits or comments
-            if ticket.get('status') == 'deleted':
-                continue
 
             # Check if the number of ticket IDs has reached the batch size.
             ticket_ids.append(ticket["id"])

--- a/test/unittests/test_async_ticket_audits.py
+++ b/test/unittests/test_async_ticket_audits.py
@@ -187,6 +187,61 @@ class TestASyncTicketAudits(unittest.TestCase):
         # Assertions
         self.assertEqual(len(result), 2)
 
+    @patch('tap_zendesk.streams.time.sleep')
+    @patch("tap_zendesk.streams.Tickets.update_bookmark")
+    @patch("tap_zendesk.streams.Tickets.get_bookmark")
+    @patch("tap_zendesk.streams.Tickets.get_objects")
+    @patch("tap_zendesk.streams.Tickets.check_access")
+    @patch("tap_zendesk.streams.singer.write_state")
+    @patch("tap_zendesk.streams.zendesk_metrics.capture")
+    @patch("tap_zendesk.streams.LOGGER.info")
+    def test_concurrency_for_audit_stream(
+        self,
+        mock_info,
+        mock_capture,
+        mock_write_state,
+        mock_check_access,
+        mock_get_objects,
+        mock_get_bookmark,
+        mock_update_bookmark,
+        mock_sleep
+    ):
+        """
+        Test that sync does not extract records for audits and comments when both of them are not selected.
+        """
+        # Mock the necessary data
+        state = {}
+        bookmark = "2023-01-01T00:00:00Z"
+        tickets = [
+            {"id": 1, "generated_timestamp": 1672531200, "fields": "duplicate"},
+            {"id": 2, "generated_timestamp": 1672531300, "fields": "duplicate"},
+            {"id": 3, "generated_timestamp": 1672531200, "fields": "duplicate"},
+            {"id": 4, "generated_timestamp": 1672531300, "fields": "duplicate"},
+            {"id": 5, "generated_timestamp": 1672531300, "fields": "duplicate"},
+            {"id": 6, "generated_timestamp": 1672531300, "fields": "duplicate"},
+            {"id": 7, "generated_timestamp": 1672531300, "fields": "duplicate"},
+            {"id": 8, "generated_timestamp": 1672531300, "fields": "duplicate"},
+            {"id": 9, "generated_timestamp": 1672531300, "fields": "duplicate"}
+        ]
+        mock_get_bookmark.return_value = bookmark
+        mock_get_objects.return_value = tickets
+        streams.AUDITS_REQUEST_PER_MINUTE = 4
+        streams.CONCURRENCY_LIMIT = 2
+
+        # Create an instance of the Tickets class
+        instance = streams.Tickets(None, {})
+        instance.sync_ticket_audits_and_comments = MagicMock(return_value=[
+            (['audit1', 'audit2'], ['comment1', 'comment2']),
+            (['audit3', 'audit4'], ['comment3', 'comment4']),
+        ])
+
+        # Run the sync method
+        result = list(instance.sync(state))
+
+        # Assertions
+        self.assertEqual(mock_write_state.call_count, 5)
+        self.assertEqual(mock_sleep.call_count, 2)
+
     @patch("tap_zendesk.streams.zendesk_metrics.capture")
     @patch("tap_zendesk.streams.LOGGER.warning")
     @patch(


### PR DESCRIPTION
# Description of change
- Add backoff for 5xx errors.
- Reduce concurrent request limit to 20.
- Make a maximum of 450 ticket_audit([an endpoint specific rate limit](https://developer.zendesk.com/api-reference/introduction/rate-limits/#endpoint-rate-limits:~:text=List%20Audits%20for,requests%20per%20minute)) API calls per minute. If it hits 450 call within a minute, then wait for the  remaining seconds.

# Manual QA steps
 - Run the sync mode and verify that the tap hits a max of 20 concurrent requests at a time.
 - Run the sync mode and verify that tap retries on any 5xx errors.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
