### PR TITLE
Upgrade aiohttp and requests lib version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.6.2
+  * Upgrade aiohttp and requests lib versions to 3.11.9 and 2.32.3 respectively. [#155](https://github.com/singer-io/tap-zendesk/pull/157)
+
 ## 2.6.1
   * Retry for 5xx errors and resolve too many 429 errors [#155](https://github.com/singer-io/tap-zendesk/pull/155)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.6.2
-  * Upgrade aiohttp and requests lib versions to 3.11.9 and 2.32.3 respectively. [#155](https://github.com/singer-io/tap-zendesk/pull/157)
+  * Upgrade aiohttp and requests lib versions to 3.11.9 and 2.32.3 respectively. [#157](https://github.com/singer-io/tap-zendesk/pull/157)
 
 ## 2.6.1
   * Retry for 5xx errors and resolve too many 429 errors [#155](https://github.com/singer-io/tap-zendesk/pull/155)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='tap-zendesk',
           'zenpy==2.0.24',
           'backoff==2.2.1',
           'requests==2.32.3',
-          'aiohttp==3.11.9'
+          'aiohttp==3.11.11'
       ],
       extras_require={
           'dev': [

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ setup(name='tap-zendesk',
           'singer-python==6.0.0',
           'zenpy==2.0.24',
           'backoff==2.2.1',
-          'requests==2.31.0',
-          'aiohttp==3.10.10'
+          'requests==2.32.3',
+          'aiohttp==3.11.9'
       ],
       extras_require={
           'dev': [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='2.6.1',
+      version='2.6.2',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
- Upgrade aiohttp and requests lib versions to `3.11.9` and `2.32.3` respectively.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
