### PR TITLE
Fix incremental extraction issue for macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.6.3
+  * Replace [#search](https://developer.zendesk.com/api-reference/ticketing/ticket-management/search/?_gl=1*1kjhwjj*_ga*NjA2MTA1ODg0LjE3NDQ3MTg3NDI.*_ga_0G6FC9CS2V*MTc0NDcxODg3OS4xLjEuMTc0NDcyMDM2Mi41Ni4wLjA.#export-search-results) endpoint for macros stream with [#list-macros](https://developer.zendesk.com/api-reference/ticketing/business-rules/macros/#list-macros) endpoint. [#158](https://github.com/singer-io/tap-zendesk/pull/158)
+
 ## 2.6.2
   * Upgrade aiohttp and requests lib versions to 3.11.9 and 2.32.3 respectively. [#157](https://github.com/singer-io/tap-zendesk/pull/157)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='2.6.2',
+      version='2.6.3',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
We are using this [search](https://developer.zendesk.com/api-reference/ticketing/ticket-management/search/?_gl=1*1kjhwjj*_ga*NjA2MTA1ODg0LjE3NDQ3MTg3NDI.*_ga_0G6FC9CS2V*MTc0NDcxODg3OS4xLjEuMTc0NDcyMDM2Mi41Ni4wLjA.#export-search-results) endpoint, which returns up to 1000 results per query with a maximum of 100 results per page. If we request past the limit, a 422 response is expected according to this [reference](https://support.zendesk.com/hc/en-us/community/posts/4409222763930-API-error-Invalid-search-Requested-response-size-was-greater-than-Search-Response-Limits).

So, replace the endpoint with the [list-macros](https://developer.zendesk.com/api-reference/ticketing/business-rules/macros/#list-macros) endpoint, which will fetch all the `macros` records without any error.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
