### PR TITLE
[SAC-28940]- Sync implementation for `activities` and `audit_logs` streams

### DIFF
--- a/tap_zendesk/streams/__init__.py
+++ b/tap_zendesk/streams/__init__.py
@@ -1,3 +1,5 @@
+from tap_zendesk.streams.activities import Activities
+from tap_zendesk.streams.audit_logs import AuditLogs
 from tap_zendesk.streams.automations import Automations
 from tap_zendesk.streams.bookmarks import Bookmarks
 from tap_zendesk.streams.brands import Brands
@@ -25,6 +27,8 @@ from tap_zendesk.streams.users import Users
 
 
 STREAMS = {
+    "activities": Activities,
+    "audit_logs": AuditLogs,
     "automations": Automations,
     "bookmarks": Bookmarks,
     "brands": Brands,

--- a/tap_zendesk/streams/activities.py
+++ b/tap_zendesk/streams/activities.py
@@ -1,0 +1,13 @@
+from tap_zendesk.streams.abstracts import (
+    PaginatedStream
+)
+
+
+class Activities(PaginatedStream):
+    name = "activities"
+    replication_method = "INCREMENTAL"
+    replication_key = "updated_at"
+    key_properties = ["id"]
+    endpoint = 'activities'
+    item_key = 'activities'
+    pagination_type = "offset"

--- a/tap_zendesk/streams/audit_logs.py
+++ b/tap_zendesk/streams/audit_logs.py
@@ -1,0 +1,13 @@
+from tap_zendesk.streams.abstracts import (
+    PaginatedStream
+)
+
+
+class AuditLogs(PaginatedStream):
+    name = "audit_logs"
+    replication_method = "INCREMENTAL"
+    replication_key = "created_at"
+    key_properties = ["id"]
+    endpoint = 'audit_logs'
+    item_key = 'audit_logs'
+    pagination_type = "offset"


### PR DESCRIPTION
# Description of change
This PR covers sync implementation for streams:
- activities
- audit_logs

# Manual QA steps
 - [x]  Discovery: running
 - [ ]  Sync: not running (fixing)
  
# Rollback steps
 - revert this branch
