### PR TITLE
[SAC-28940]- Sync implementation for `requests` streams - Part 2

### DIFF
--- a/tap_zendesk/schemas/account_attribute_definitions.json
+++ b/tap_zendesk/schemas/account_attribute_definitions.json
@@ -7,7 +7,10 @@
                 "null"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "null"
+                ],
                 "properties": {
                     "subject": {
                         "type": [
@@ -30,7 +33,10 @@
                 "null"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "null"
+                ],
                 "properties": {
                     "subject": {
                         "type": [

--- a/tap_zendesk/schemas/automations.json
+++ b/tap_zendesk/schemas/automations.json
@@ -51,7 +51,10 @@
                 "null"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "null"
+                ],
                 "properties": {
                     "field": {
                         "type": [
@@ -80,7 +83,10 @@
                         "null"
                     ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "field": {
                                 "type": [
@@ -109,7 +115,10 @@
                         "null"
                     ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "field": {
                                 "type": [

--- a/tap_zendesk/schemas/bookmarks.json
+++ b/tap_zendesk/schemas/bookmarks.json
@@ -74,7 +74,10 @@
                         "null"
                     ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "email": {
                                 "type": [
@@ -104,7 +107,10 @@
                         "null"
                     ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "id": {
                                 "type": [

--- a/tap_zendesk/schemas/dynamic_content_items.json
+++ b/tap_zendesk/schemas/dynamic_content_items.json
@@ -19,7 +19,10 @@
                 "null"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "null"
+                ],
                 "properties": {
                     "content": {
                         "type": [

--- a/tap_zendesk/schemas/job_statuses.json
+++ b/tap_zendesk/schemas/job_statuses.json
@@ -31,7 +31,10 @@
                 "null"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "null"
+                ],
                 "properties": {
                     "id": {
                         "type": [

--- a/tap_zendesk/schemas/macro_actions.json
+++ b/tap_zendesk/schemas/macro_actions.json
@@ -19,7 +19,38 @@
                         "null"
                     ]
                 },
-                "additionalProperties": true
+                "list": {
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "items": {
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "properties": {
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "title": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "enabled": {
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ]
+                            }
+                        }
+                    }
+                }
             }
         },
         "value": {
@@ -34,7 +65,10 @@
                 "null"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "null"
+                ],
                 "properties": {
                     "value": {
                         "type": [

--- a/tap_zendesk/schemas/macro_categories.json
+++ b/tap_zendesk/schemas/macro_categories.json
@@ -1,9 +1,11 @@
 {
-    "type": "array",
-    "items": {
-        "type": [
-            "string",
-            "null"
-        ]
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": [
+                "string",
+                "null"
+            ]
+        }
     }
 }

--- a/tap_zendesk/schemas/organizations.json
+++ b/tap_zendesk/schemas/organizations.json
@@ -41,7 +41,7 @@
         "object"
       ],
       "additionalProperties": true
-     },
+    },
     "notes": {
       "type": [
         "null",

--- a/tap_zendesk/schemas/resource_collections.json
+++ b/tap_zendesk/schemas/resource_collections.json
@@ -20,7 +20,10 @@
                 "null"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "null"
+                ],
                 "properties": {
                     "deleted": {
                         "type": [

--- a/tap_zendesk/schemas/schedules.json
+++ b/tap_zendesk/schemas/schedules.json
@@ -32,7 +32,10 @@
                 "null"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "null"
+                ],
                 "properties": {
                     "start_time": {
                         "type": [

--- a/tap_zendesk/schemas/side_conversations.json
+++ b/tap_zendesk/schemas/side_conversations.json
@@ -41,7 +41,10 @@
                 "null"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "null"
+                ],
                 "properties": {
                     "email": {
                         "type": [

--- a/tap_zendesk/schemas/sla_policies.json
+++ b/tap_zendesk/schemas/sla_policies.json
@@ -32,7 +32,10 @@
     "filter": {
       "properties": {
         "all": {
-          "type": ["null", "array"],
+          "type": [
+            "null",
+            "array"
+          ],
           "items": {
             "properties": {
               "field": {
@@ -54,7 +57,9 @@
                 ]
               }
             },
-            "type": ["object"]
+            "type": [
+              "object"
+            ]
           }
         },
         "any": {
@@ -83,11 +88,16 @@
                 ]
               }
             },
-            "type": ["object"]
+            "type": [
+              "object"
+            ]
           }
         }
       },
-      "type": ["null", "object"]
+      "type": [
+        "null",
+        "object"
+      ]
     },
     "policy_metrics": {
       "type": [
@@ -96,10 +106,25 @@
       ],
       "items": {
         "properties": {
-          "priority": { "type": ["null", "string"] },
-          "target": { "type": ["null", "integer"] },
-          "business_hours": { "type": ["null", "boolean"] },
-          "metric": { }
+          "priority": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "target": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "business_hours": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "metric": {}
         },
         "type": [
           "null",

--- a/tap_zendesk/schemas/support_requests.json
+++ b/tap_zendesk/schemas/support_requests.json
@@ -41,7 +41,10 @@
                 "null"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "null"
+                ],
                 "properties": {
                     "id": {
                         "type": [

--- a/tap_zendesk/schemas/suspended_tickets.json
+++ b/tap_zendesk/schemas/suspended_tickets.json
@@ -7,7 +7,10 @@
                 "null"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "null"
+                ],
                 "properties": {
                     "content_type": {
                         "type": [
@@ -93,7 +96,10 @@
                             "null"
                         ],
                         "items": {
-                            "type": "object",
+                            "type": [
+                                "object",
+                                "null"
+                            ],
                             "properties": {
                                 "content_type": {
                                     "type": [

--- a/tap_zendesk/schemas/talk_phone_numbers.json
+++ b/tap_zendesk/schemas/talk_phone_numbers.json
@@ -31,14 +31,14 @@
       }
     },
     "categorised_greetings": {
-      "properties": { },
+      "properties": {},
       "type": [
         "null",
         "object"
       ]
     },
     "categorised_greetings_with_sub_settings": {
-      "properties": { },
+      "properties": {},
       "type": [
         "null",
         "object"
@@ -58,7 +58,10 @@
       "format": "date-time"
     },
     "default_greeting_ids": {
-      "type": ["null", "array"],
+      "type": [
+        "null",
+        "array"
+      ],
       "items": {
         "type": [
           "null",
@@ -85,7 +88,10 @@
       ]
     },
     "greeting_ids": {
-      "type": ["null", "array"],
+      "type": [
+        "null",
+        "array"
+      ],
       "items": {
         "type": [
           "null",
@@ -94,7 +100,10 @@
       }
     },
     "group_ids": {
-      "type": ["null", "array"],
+      "type": [
+        "null",
+        "array"
+      ],
       "items": {
         "type": [
           "null",
@@ -107,7 +116,7 @@
         "string"
       ]
     },
-     "ivr_id": {
+    "ivr_id": {
       "type": [
         "null",
         "integer"

--- a/tap_zendesk/schemas/ticket_audits.json
+++ b/tap_zendesk/schemas/ticket_audits.json
@@ -167,8 +167,8 @@
             "type": [
               "null",
               "string"
-             ],
-             "format": "date-time"
+            ],
+            "format": "date-time"
           },
           "data": {
             "type": [
@@ -183,10 +183,10 @@
                 ]
               },
               "transcription_text": {
-                 "type": [
-                   "null",
-                   "string"
-                 ]
+                "type": [
+                  "null",
+                  "string"
+                ]
               },
               "to": {
                 "type": [

--- a/tap_zendesk/schemas/ticket_comments.json
+++ b/tap_zendesk/schemas/ticket_comments.json
@@ -61,9 +61,15 @@
         "integer"
       ]
     },
-    "via": {"$ref": "shared/via.json"},
-    "metadata": {"$ref": "shared/metadata.json"},
-    "attachments": {"$ref": "shared/attachments.json"}
+    "via": {
+      "$ref": "shared/via.json"
+    },
+    "metadata": {
+      "$ref": "shared/metadata.json"
+    },
+    "attachments": {
+      "$ref": "shared/attachments.json"
+    }
   },
   "type": [
     "null",

--- a/tap_zendesk/schemas/ticket_forms.json
+++ b/tap_zendesk/schemas/ticket_forms.json
@@ -82,8 +82,8 @@
     },
     "restricted_brand_ids": {
       "type": [
-          "null",
-          "array"
+        "null",
+        "array"
       ],
       "items": {
         "type": [
@@ -94,8 +94,8 @@
     },
     "ticket_field_ids": {
       "type": [
-          "null",
-          "array"
+        "null",
+        "array"
       ],
       "items": {
         "type": [
@@ -104,7 +104,6 @@
         ]
       }
     }
-
   },
   "type": [
     "null",

--- a/tap_zendesk/schemas/ticket_skips.json
+++ b/tap_zendesk/schemas/ticket_skips.json
@@ -74,7 +74,10 @@
                         "null"
                     ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "email": {
                                 "type": [
@@ -104,7 +107,10 @@
                         "null"
                     ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "id": {
                                 "type": [

--- a/tap_zendesk/schemas/tickets.json
+++ b/tap_zendesk/schemas/tickets.json
@@ -143,7 +143,7 @@
               "integer"
             ]
           },
-          "value": { }
+          "value": {}
         },
         "type": [
           "null",
@@ -310,42 +310,78 @@
       ],
       "properties": {
         "id": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "assignee_id": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "group_id": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "reason_id": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "requester_id": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "ticket_id": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "updated_at": {
-            "type": ["null", "string"],
-            "format": "date-time"
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
         },
         "created_at": {
-            "type": ["null", "string"],
-            "format": "date-time"
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
         },
         "url": {
-            "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "score": {
-            "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "reason": {
-            "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "comment": {
-            "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         }
       }
     },

--- a/tap_zendesk/schemas/trigger_revisions.json
+++ b/tap_zendesk/schemas/trigger_revisions.json
@@ -26,7 +26,10 @@
                         "null"
                     ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "field": {
                                 "type": [
@@ -34,7 +37,10 @@
                                     "null"
                                 ],
                                 "items": {
-                                    "type": "object",
+                                    "type": [
+                                        "object",
+                                        "null"
+                                    ],
                                     "properties": {
                                         "change": {
                                             "type": [
@@ -57,7 +63,10 @@
                                     "null"
                                 ],
                                 "items": {
-                                    "type": "object",
+                                    "type": [
+                                        "object",
+                                        "null"
+                                    ],
                                     "properties": {
                                         "change": {
                                             "type": [
@@ -83,7 +92,10 @@
                         "null"
                     ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "change": {
                                 "type": [
@@ -112,7 +124,10 @@
                                 "null"
                             ],
                             "items": {
-                                "type": "object",
+                                "type": [
+                                    "object",
+                                    "null"
+                                ],
                                 "properties": {
                                     "change": {
                                         "type": [
@@ -135,7 +150,10 @@
                                 "null"
                             ],
                             "items": {
-                                "type": "object",
+                                "type": [
+                                    "object",
+                                    "null"
+                                ],
                                 "properties": {
                                     "change": {
                                         "type": [
@@ -158,7 +176,10 @@
                                 "null"
                             ],
                             "items": {
-                                "type": "object",
+                                "type": [
+                                    "object",
+                                    "null"
+                                ],
                                 "properties": {
                                     "change": {
                                         "type": [
@@ -183,7 +204,10 @@
                         "null"
                     ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "change": {
                                 "type": [
@@ -218,7 +242,10 @@
                         "null"
                     ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "change": {
                                 "type": [
@@ -255,7 +282,10 @@
                         "null"
                     ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "field": {
                                 "type": [
@@ -290,7 +320,10 @@
                                 "null"
                             ],
                             "items": {
-                                "type": "object",
+                                "type": [
+                                    "object",
+                                    "null"
+                                ],
                                 "properties": {
                                     "field": {
                                         "type": [
@@ -319,7 +352,10 @@
                                 "null"
                             ],
                             "items": {
-                                "type": "object",
+                                "type": [
+                                    "object",
+                                    "null"
+                                ],
                                 "properties": {
                                     "field": {
                                         "type": [

--- a/tap_zendesk/schemas/triggers.json
+++ b/tap_zendesk/schemas/triggers.json
@@ -51,7 +51,10 @@
                 "null"
             ],
             "items": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "null"
+                ],
                 "properties": {
                     "field": {
                         "type": [
@@ -62,7 +65,10 @@
                     "value": {
                         "anyOf": [
                             {
-                                "type": "array",
+                                "type": [
+                                    "array",
+                                    "null"
+                                ],
                                 "items": {
                                     "type": [
                                         "string",
@@ -93,7 +99,10 @@
                         "null"
                     ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "field": {
                                 "type": [
@@ -123,7 +132,10 @@
                         "null"
                     ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "field": {
                                 "type": [

--- a/tap_zendesk/schemas/views.json
+++ b/tap_zendesk/schemas/views.json
@@ -58,7 +58,10 @@
             ]
         },
         "execution": {
-            "type": "object",
+            "type": [
+                "object",
+                "null"
+            ],
             "properties": {
                 "group_by": {
                     "type": [
@@ -85,7 +88,10 @@
                     ]
                 },
                 "group": {
-                    "type": "object",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
                     "properties": {
                         "id": {
                             "type": [
@@ -120,7 +126,10 @@
                     }
                 },
                 "sort": {
-                    "type": "object",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
                     "properties": {
                         "id": {
                             "type": [
@@ -155,9 +164,15 @@
                     }
                 },
                 "columns": {
-                    "type": "array",
+                    "type": [
+                        "array",
+                        "null"
+                    ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "id": {
                                 "type": [
@@ -187,9 +202,15 @@
                     }
                 },
                 "fields": {
-                    "type": "array",
+                    "type": [
+                        "array",
+                        "null"
+                    ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "id": {
                                 "type": [
@@ -219,9 +240,15 @@
                     }
                 },
                 "custom_fields": {
-                    "type": "array",
+                    "type": [
+                        "array",
+                        "null"
+                    ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "id": {
                                 "type": [
@@ -253,12 +280,21 @@
             }
         },
         "conditions": {
-            "type": "object",
+            "type": [
+                "object",
+                "null"
+            ],
             "properties": {
                 "all": {
-                    "type": "array",
+                    "type": [
+                        "array",
+                        "null"
+                    ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "field": {
                                 "type": [
@@ -282,9 +318,15 @@
                     }
                 },
                 "any": {
-                    "type": "array",
+                    "type": [
+                        "array",
+                        "null"
+                    ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "field": {
                                 "type": [

--- a/tap_zendesk/schemas/workspaces.json
+++ b/tap_zendesk/schemas/workspaces.json
@@ -8,19 +8,33 @@
             ]
         },
         "apps": {
-            "type": "array",
+            "type": [
+                "array",
+                "null"
+            ],
             "items": {
-                "type": "object",
-                "additionalProperties": true
+                "type": [
+                    "object",
+                    "null"
+                ]
             }
         },
         "conditions": {
-            "type": "object",
+            "type": [
+                "object",
+                "null"
+            ],
             "properties": {
                 "all": {
-                    "type": "array",
+                    "type": [
+                        "array",
+                        "null"
+                    ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "field": {
                                 "type": [
@@ -44,9 +58,15 @@
                     }
                 },
                 "any": {
-                    "type": "array",
+                    "type": [
+                        "array",
+                        "null"
+                    ],
                     "items": {
-                        "type": "object",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
                         "properties": {
                             "field": {
                                 "type": [
@@ -91,7 +111,10 @@
             ]
         },
         "macro_ids": {
-            "type": "array",
+            "type": [
+                "array",
+                "null"
+            ],
             "items": {
                 "type": [
                     "string",
@@ -100,7 +123,10 @@
             }
         },
         "macros": {
-            "type": "array",
+            "type": [
+                "array",
+                "null"
+            ],
             "items": {
                 "type": [
                     "integer",
@@ -121,14 +147,26 @@
             ]
         },
         "selected_macros": {
-            "type": "array",
+            "type": [
+                "array",
+                "null"
+            ],
             "items": {
-                "type": "object",
+                "type": [
+                    "object",
+                    "null"
+                ],
                 "properties": {
                     "actions": {
-                        "type": "array",
+                        "type": [
+                            "array",
+                            "null"
+                        ],
                         "items": {
-                            "type": "object",
+                            "type": [
+                                "object",
+                                "null"
+                            ],
                             "properties": {
                                 "field": {
                                     "type": [
@@ -189,8 +227,10 @@
                         ]
                     },
                     "restriction": {
-                        "type": "object",
-                        "additionalProperties": true
+                        "type": [
+                            "object",
+                            "null"
+                        ]
                     },
                     "updated_at": {
                         "type": [

--- a/tap_zendesk/streams/__init__.py
+++ b/tap_zendesk/streams/__init__.py
@@ -31,6 +31,24 @@ from tap_zendesk.streams.ticket_metric_events import TicketMetricEvents
 from tap_zendesk.streams.ticket_metrics import TicketMetrics
 from tap_zendesk.streams.tickets import Tickets
 from tap_zendesk.streams.users import Users
+from tap_zendesk.streams.account_attribute_definitions import AccountAttributeDefinitions
+from tap_zendesk.streams.account_attributes import AccountAttributes
+from tap_zendesk.streams.locales import Locales
+from tap_zendesk.streams.job_statuses import JobStatuses
+from tap_zendesk.streams.macro_actions import MacroActions
+from tap_zendesk.streams.macro_categories import MacroCategories
+from tap_zendesk.streams.macro_definitions import MacroDefinitions
+from tap_zendesk.streams.monitored_twitter_handles import MonitoredTwitterHandles
+from tap_zendesk.streams.organization_memberships import OrganizationMemberships
+from tap_zendesk.streams.organization_subscriptions import OrganizationSubscriptions
+from tap_zendesk.streams.support_requests import SupportRequests
+from tap_zendesk.streams.resource_collections import ResourceCollections
+from tap_zendesk.streams.satisfaction_reasons import SatisfactionReasons
+from tap_zendesk.streams.schedules import Schedules
+from tap_zendesk.streams.trigger_categories import TriggerCategories
+from tap_zendesk.streams.triggers import Triggers
+from tap_zendesk.streams.views import Views
+from tap_zendesk.streams.workspaces import Workspaces
 
 
 STREAMS = {
@@ -66,5 +84,23 @@ STREAMS = {
     "ticket_forms": TicketForms,
     "ticket_metrics": TicketMetrics,
     "ticket_metric_events": TicketMetricEvents,
-    "users": Users
+    "users": Users,
+    "account_attribute_definitions": AccountAttributeDefinitions,
+    "account_attributes": AccountAttributes,
+    "locales": Locales,
+    "job_statuses": JobStatuses,
+    "macro_actions": MacroActions,
+    "macro_categories": MacroCategories,
+    "macro_definitions": MacroDefinitions,
+    "monitored_twitter_handles": MonitoredTwitterHandles,
+    "organization_memberships": OrganizationMemberships,
+    "organization_subscriptions": OrganizationSubscriptions,
+    "support_requests": SupportRequests,
+    "resource_collections": ResourceCollections,
+    "satisfaction_reasons": SatisfactionReasons,
+    "schedules": Schedules,
+    "triggers": Triggers,
+    "trigger_categories": TriggerCategories,
+    "views": Views,
+    "workspaces": Workspaces
 }

--- a/tap_zendesk/streams/__init__.py
+++ b/tap_zendesk/streams/__init__.py
@@ -12,6 +12,7 @@ from tap_zendesk.streams.groups import Groups
 from tap_zendesk.streams.group_memberships import GroupMemberships
 from tap_zendesk.streams.macros import Macros
 from tap_zendesk.streams.organizations import Organizations
+from tap_zendesk.streams.requests import Requests
 from tap_zendesk.streams.satisfaction_ratings import SatisfactionRatings
 from tap_zendesk.streams.sessions import Sessions
 from tap_zendesk.streams.sharing_agreements import SharingAgreements
@@ -66,6 +67,7 @@ STREAMS = {
     "group_memberships": GroupMemberships,
     "macros": Macros,
     "organizations": Organizations,
+    "requests": Requests,
     "satisfaction_ratings": SatisfactionRatings,
     "sessions": Sessions,
     "sharing_agreements": SharingAgreements,

--- a/tap_zendesk/streams/abstracts.py
+++ b/tap_zendesk/streams/abstracts.py
@@ -163,6 +163,18 @@ class Stream():
         """
         return record
 
+    def get_nested_value(self, data, key_path, default=None):
+        """
+        Recursively get a value from nested dicts using dot-separated key path.
+        """
+        keys = key_path.split(".")
+        for key in keys:
+            if isinstance(data, dict):
+                data = data.get(key, default)
+            else:
+                return default
+        return data
+
 class PaginatedStream(Stream):
     pagination_type = None
     item_key = None
@@ -189,7 +201,7 @@ class PaginatedStream(Stream):
         )
 
         for page in pages:
-            raw_records = page[self.item_key]
+            raw_records = self.get_nested_value(page, self.item_key, [])
             if isinstance(raw_records, dict):
                 yield from [raw_records]
 

--- a/tap_zendesk/streams/account_attribute_definitions.py
+++ b/tap_zendesk/streams/account_attribute_definitions.py
@@ -1,0 +1,10 @@
+from tap_zendesk.streams.abstracts import (
+    PaginatedStream
+)
+
+class AccountAttributeDefinitions(PaginatedStream):
+    name = "account_attribute_definitions"
+    replication_method = "FULL_TABLE"
+    endpoint = 'routing/attributes/definitions'
+    item_key = 'definitions'
+    pagination_type = "offset"

--- a/tap_zendesk/streams/account_attributes.py
+++ b/tap_zendesk/streams/account_attributes.py
@@ -2,11 +2,11 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-class Activities(PaginatedStream):
-    name = "activities"
+class AccountAttributes(PaginatedStream):
+    name = "account_attributes"
     replication_method = "INCREMENTAL"
     replication_key = "updated_at"
     key_properties = ["id"]
-    endpoint = 'activities'
-    item_key = 'activities'
-    pagination_type = "cursor"
+    endpoint = 'routing/attributes'
+    item_key = 'attributes'
+    pagination_type = "offset"

--- a/tap_zendesk/streams/audit_logs.py
+++ b/tap_zendesk/streams/audit_logs.py
@@ -2,7 +2,6 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-
 class AuditLogs(PaginatedStream):
     name = "audit_logs"
     replication_method = "INCREMENTAL"
@@ -10,4 +9,4 @@ class AuditLogs(PaginatedStream):
     key_properties = ["id"]
     endpoint = 'audit_logs'
     item_key = 'audit_logs'
-    pagination_type = "offset"
+    pagination_type = "cursor"

--- a/tap_zendesk/streams/automations.py
+++ b/tap_zendesk/streams/automations.py
@@ -10,4 +10,4 @@ class Automations(PaginatedStream):
     key_properties = ["id"]
     endpoint = 'automations'
     item_key = 'automations'
-    pagination_type = "offset"
+    pagination_type = "cursor"

--- a/tap_zendesk/streams/bookmarks.py
+++ b/tap_zendesk/streams/bookmarks.py
@@ -2,7 +2,6 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-
 class Bookmarks(PaginatedStream):
     name = "bookmarks"
     replication_method = "INCREMENTAL"

--- a/tap_zendesk/streams/brands.py
+++ b/tap_zendesk/streams/brands.py
@@ -2,7 +2,6 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-
 class Brands(PaginatedStream):
     name = "brands"
     replication_method = "INCREMENTAL"
@@ -10,4 +9,4 @@ class Brands(PaginatedStream):
     key_properties = ["id"]
     endpoint = 'brands'
     item_key = 'brands'
-    pagination_type = "offset"
+    pagination_type = "cursor"

--- a/tap_zendesk/streams/deleted_tickets.py
+++ b/tap_zendesk/streams/deleted_tickets.py
@@ -2,12 +2,11 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-
 class DeletedTickets(PaginatedStream):
     name = "deleted_tickets"
     replication_method = "INCREMENTAL"
-    replication_key = "updated_at"
+    replication_key = "deleted_at"
     key_properties = ["id"]
     endpoint = 'deleted_tickets'
     item_key = 'deleted_tickets'
-    pagination_type = "offset"
+    pagination_type = "cursor"

--- a/tap_zendesk/streams/deleted_users.py
+++ b/tap_zendesk/streams/deleted_users.py
@@ -2,7 +2,6 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-
 class DeletedUsers(PaginatedStream):
     name = "deleted_users"
     replication_method = "INCREMENTAL"
@@ -10,4 +9,4 @@ class DeletedUsers(PaginatedStream):
     key_properties = ["id"]
     endpoint = 'deleted_users'
     item_key = 'deleted_users'
-    pagination_type = "offset"
+    pagination_type = "cursor"

--- a/tap_zendesk/streams/dynamic_content_items.py
+++ b/tap_zendesk/streams/dynamic_content_items.py
@@ -2,7 +2,6 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-
 class DynamicContentItems(PaginatedStream):
     name = "dynamic_content_items"
     replication_method = "INCREMENTAL"
@@ -10,4 +9,4 @@ class DynamicContentItems(PaginatedStream):
     key_properties = ["id"]
     endpoint = 'dynamic_content/items'
     item_key = 'items'
-    pagination_type = "offset"
+    pagination_type = "cursor"

--- a/tap_zendesk/streams/group_memberships.py
+++ b/tap_zendesk/streams/group_memberships.py
@@ -5,7 +5,6 @@ from tap_zendesk.streams.abstracts import (
     LOGGER
 )
 
-
 class GroupMemberships(PaginatedStream):
     name = "group_memberships"
     replication_method = "INCREMENTAL"

--- a/tap_zendesk/streams/groups.py
+++ b/tap_zendesk/streams/groups.py
@@ -2,7 +2,6 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-
 class Groups(PaginatedStream):
     name = "groups"
     replication_method = "INCREMENTAL"

--- a/tap_zendesk/streams/job_statuses.py
+++ b/tap_zendesk/streams/job_statuses.py
@@ -1,0 +1,12 @@
+from tap_zendesk.streams.abstracts import (
+    PaginatedStream
+)
+
+
+class JobStatuses(PaginatedStream):
+    name = "job_statuses"
+    replication_method = "FULL_TABLE"
+    key_properties = ["id"]
+    endpoint = 'job_statuses'
+    item_key = 'job_statuses'
+    pagination_type = "cursor"

--- a/tap_zendesk/streams/locales.py
+++ b/tap_zendesk/streams/locales.py
@@ -2,11 +2,11 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-class Activities(PaginatedStream):
-    name = "activities"
+class Locales(PaginatedStream):
+    name = "locales"
     replication_method = "INCREMENTAL"
     replication_key = "updated_at"
     key_properties = ["id"]
-    endpoint = 'activities'
-    item_key = 'activities'
-    pagination_type = "cursor"
+    endpoint = 'locales'
+    item_key = 'locales'
+    pagination_type = "offset"

--- a/tap_zendesk/streams/macro_actions.py
+++ b/tap_zendesk/streams/macro_actions.py
@@ -1,0 +1,11 @@
+from tap_zendesk.streams.abstracts import (
+    PaginatedStream
+)
+
+class MacroActions(PaginatedStream):
+    name = "macro_actions"
+    replication_method = "FULL_TABLE"
+    key_properties = ["field"]
+    endpoint = 'macros/actions'
+    item_key = 'actions'
+    pagination_type = "offset"

--- a/tap_zendesk/streams/macro_categories.py
+++ b/tap_zendesk/streams/macro_categories.py
@@ -1,0 +1,20 @@
+from tap_zendesk.streams.abstracts import (
+    PaginatedStream
+)
+
+class MacroCategories(PaginatedStream):
+    name = "macro_categories"
+    replication_method = "FULL_TABLE"
+    key_properties = ["name"]
+    endpoint = 'macros/categories'
+    item_key = 'categories'
+    pagination_type = "offset"
+
+    def modify_object(self, record, **_kwargs):
+        """
+        Overriding modify_record to add `name` key in recordssss
+        """
+        record_dict = {
+            "name": record
+        }
+        return record_dict

--- a/tap_zendesk/streams/macro_definitions.py
+++ b/tap_zendesk/streams/macro_definitions.py
@@ -1,0 +1,11 @@
+from tap_zendesk.streams.abstracts import (
+    PaginatedStream
+)
+
+class MacroDefinitions(PaginatedStream):
+    name = "macro_definitions"
+    replication_method = "FULL_TABLE"
+    key_properties = ["subject"]
+    endpoint = 'macros/definitions'
+    item_key = 'definitions.actions'
+    pagination_type = "offset"

--- a/tap_zendesk/streams/monitored_twitter_handles.py
+++ b/tap_zendesk/streams/monitored_twitter_handles.py
@@ -2,11 +2,11 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-class CustomRoles(PaginatedStream):
-    name = "custom_roles"
+class MonitoredTwitterHandles(PaginatedStream):
+    name = "monitored_twitter_handles"
     replication_method = "INCREMENTAL"
     replication_key = "updated_at"
     key_properties = ["id"]
-    endpoint = 'custom_roles'
-    item_key = 'custom_roles'
+    endpoint = 'channels/twitter/monitored_twitter_handles'
+    item_key = 'monitored_twitter_handles'
     pagination_type = "offset"

--- a/tap_zendesk/streams/organization_memberships.py
+++ b/tap_zendesk/streams/organization_memberships.py
@@ -2,11 +2,11 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-class Activities(PaginatedStream):
-    name = "activities"
+class OrganizationMemberships(PaginatedStream):
+    name = "organization_memberships"
     replication_method = "INCREMENTAL"
     replication_key = "updated_at"
     key_properties = ["id"]
-    endpoint = 'activities'
-    item_key = 'activities'
+    endpoint = 'organization_memberships'
+    item_key = 'organization_memberships'
     pagination_type = "cursor"

--- a/tap_zendesk/streams/organization_subscriptions.py
+++ b/tap_zendesk/streams/organization_subscriptions.py
@@ -2,11 +2,11 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-class Activities(PaginatedStream):
-    name = "activities"
+class OrganizationSubscriptions(PaginatedStream):
+    name = "organization_subscriptions"
     replication_method = "INCREMENTAL"
     replication_key = "updated_at"
     key_properties = ["id"]
-    endpoint = 'activities'
-    item_key = 'activities'
+    endpoint = 'organization_subscriptions'
+    item_key = 'organization_subscriptions'
     pagination_type = "cursor"

--- a/tap_zendesk/streams/organizations.py
+++ b/tap_zendesk/streams/organizations.py
@@ -7,7 +7,6 @@ from tap_zendesk.streams.abstracts import (
     START_DATE_FORMAT
 )
 
-
 class Organizations(Stream):
     name = "organizations"
     replication_method = "INCREMENTAL"

--- a/tap_zendesk/streams/requests.py
+++ b/tap_zendesk/streams/requests.py
@@ -1,0 +1,12 @@
+from tap_zendesk.streams.abstracts import (
+    PaginatedStream
+)
+
+class Requests(PaginatedStream):
+    name = "requests"
+    replication_method = "INCREMENTAL"
+    replication_key = "updated_at"
+    key_properties = ["id"]
+    endpoint = 'requests'
+    item_key = 'requests'
+    pagination_type = "offset"

--- a/tap_zendesk/streams/resource_collections.py
+++ b/tap_zendesk/streams/resource_collections.py
@@ -2,11 +2,11 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-class CustomRoles(PaginatedStream):
-    name = "custom_roles"
+class ResourceCollections(PaginatedStream):
+    name = "resource_collections"
     replication_method = "INCREMENTAL"
     replication_key = "updated_at"
     key_properties = ["id"]
-    endpoint = 'custom_roles'
-    item_key = 'custom_roles'
+    endpoint = 'resource_collections'
+    item_key = 'resource_collections'
     pagination_type = "offset"

--- a/tap_zendesk/streams/satisfaction_reasons.py
+++ b/tap_zendesk/streams/satisfaction_reasons.py
@@ -2,11 +2,11 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-class CustomObjects(PaginatedStream):
-    name = "custom_objects"
+class SatisfactionReasons(PaginatedStream):
+    name = "satisfaction_reasons"
     replication_method = "INCREMENTAL"
     replication_key = "updated_at"
-    key_properties = ["key"]
-    endpoint = 'custom_objects'
-    item_key = 'custom_objects'
+    key_properties = ["id"]
+    endpoint = 'satisfaction_reasons'
+    item_key = 'reasons'
     pagination_type = "offset"

--- a/tap_zendesk/streams/schedules.py
+++ b/tap_zendesk/streams/schedules.py
@@ -2,11 +2,11 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-class Activities(PaginatedStream):
-    name = "activities"
+class Schedules(PaginatedStream):
+    name = "schedules"
     replication_method = "INCREMENTAL"
     replication_key = "updated_at"
     key_properties = ["id"]
-    endpoint = 'activities'
-    item_key = 'activities'
-    pagination_type = "cursor"
+    endpoint = 'business_hours/schedules'
+    item_key = 'schedules'
+    pagination_type = "offset"

--- a/tap_zendesk/streams/support_requests.py
+++ b/tap_zendesk/streams/support_requests.py
@@ -2,11 +2,11 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-class Activities(PaginatedStream):
-    name = "activities"
+class SupportRequests(PaginatedStream):
+    name = "support_requests"
     replication_method = "INCREMENTAL"
     replication_key = "updated_at"
     key_properties = ["id"]
-    endpoint = 'activities'
-    item_key = 'activities'
+    endpoint = 'requests'
+    item_key = 'requests'
     pagination_type = "cursor"

--- a/tap_zendesk/streams/tags.py
+++ b/tap_zendesk/streams/tags.py
@@ -2,7 +2,6 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-
 class Tags(PaginatedStream):
     name = "tags"
     replication_method = "FULL_TABLE"

--- a/tap_zendesk/streams/trigger_categories.py
+++ b/tap_zendesk/streams/trigger_categories.py
@@ -2,11 +2,11 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-class Activities(PaginatedStream):
-    name = "activities"
+class TriggerCategories(PaginatedStream):
+    name = "trigger_categories"
     replication_method = "INCREMENTAL"
     replication_key = "updated_at"
     key_properties = ["id"]
-    endpoint = 'activities'
-    item_key = 'activities'
+    endpoint = 'trigger_categories'
+    item_key = 'trigger_categories'
     pagination_type = "cursor"

--- a/tap_zendesk/streams/triggers.py
+++ b/tap_zendesk/streams/triggers.py
@@ -2,11 +2,11 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-class Activities(PaginatedStream):
-    name = "activities"
+class Triggers(PaginatedStream):
+    name = "triggers"
     replication_method = "INCREMENTAL"
     replication_key = "updated_at"
     key_properties = ["id"]
-    endpoint = 'activities'
-    item_key = 'activities'
+    endpoint = 'triggers'
+    item_key = 'triggers'
     pagination_type = "cursor"

--- a/tap_zendesk/streams/views.py
+++ b/tap_zendesk/streams/views.py
@@ -2,11 +2,11 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-class Activities(PaginatedStream):
-    name = "activities"
+class Views(PaginatedStream):
+    name = "views"
     replication_method = "INCREMENTAL"
     replication_key = "updated_at"
     key_properties = ["id"]
-    endpoint = 'activities'
-    item_key = 'activities'
+    endpoint = 'views'
+    item_key = 'views'
     pagination_type = "cursor"

--- a/tap_zendesk/streams/workspaces.py
+++ b/tap_zendesk/streams/workspaces.py
@@ -2,11 +2,11 @@ from tap_zendesk.streams.abstracts import (
     PaginatedStream
 )
 
-class Activities(PaginatedStream):
-    name = "activities"
+class Workspaces(PaginatedStream):
+    name = "workspaces"
     replication_method = "INCREMENTAL"
     replication_key = "updated_at"
     key_properties = ["id"]
-    endpoint = 'activities'
-    item_key = 'activities'
-    pagination_type = "cursor"
+    endpoint = 'workspaces'
+    item_key = 'workspaces'
+    pagination_type = "offset"

--- a/test/unittests/test_discovery_mode.py
+++ b/test/unittests/test_discovery_mode.py
@@ -40,19 +40,10 @@ class TestDiscovery(unittest.TestCase):
     @patch('tap_zendesk.streams.abstracts.Stream.load_metadata', return_value={})
     @patch('tap_zendesk.streams.abstracts.Stream.load_schema', return_value={})
     @patch('singer.resolve_schema_references', return_value={})
-    @patch('requests.get',
-           side_effect=[
-                mocked_get(status_code=200, json={"tickets": [{"id": "t1"}]}), # Response of the 1st get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 2nd get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 3rd get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 4th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 5th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 6th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 7th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 8th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 9th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}) # Response of the 10th get request call
-            ])
+    @patch('requests.get', side_effect=[
+        mocked_get(status_code=200, json={"key1": "val1"}),
+        *[mocked_get(status_code=403, json={"key1": "val1"}) for _ in range(50)]
+    ])
     def test_discovery_handles_403__raise_tap_zendesk_forbidden_error(self, mock_get, mock_resolve_schema_references,
                                 mock_load_metadata, mock_load_schema,mock_load_shared_schema_refs, mocked_sla_policies,
                                 mocked_ticket_forms, mock_users, mock_organizations, mocked_ticket_metric_events, mocked_talk_phone_numbers, mock_logger):
@@ -64,15 +55,19 @@ class TestDiscovery(unittest.TestCase):
 
         '''
         discover.discover_streams('dummy_client', {'subdomain': 'arp', 'access_token': 'dummy_token', 'start_date':START_DATE})
-        expected_call_count = 8
+        expected_call_count = 36
         actual_call_count = mock_get.call_count
         self.assertEqual(expected_call_count, actual_call_count)
 
         # Verifying the logger message
-        mock_logger.assert_called_with("The account credentials supplied do not have 'read' access to the following stream(s): "\
-            "group_memberships, macros, organizations, satisfaction_ratings, tags, tickets, ticket_audits, ticket_fields, "\
-            "ticket_forms, users. The data for these streams would not be collected due to lack of required "\
-            "permission.")
+        mock_logger.assert_called_with("The account credentials supplied do not have 'read' access to the following stream(s): " \
+        "audit_logs, automations, bookmarks, brands, custom_objects, custom_roles, deleted_tickets, deleted_users, " \
+        "dynamic_content_items, groups, group_memberships, macros, organizations, satisfaction_ratings, tags, tickets, " \
+        "ticket_audits, ticket_fields, ticket_forms, users, account_attribute_definitions, account_attributes, locales, " \
+        "job_statuses, macro_actions, macro_categories, macro_definitions, monitored_twitter_handles, organization_memberships, " \
+        "organization_subscriptions, support_requests, resource_collections, satisfaction_reasons, schedules, triggers, " \
+        "trigger_categories, views, workspaces. The data for these streams would not be collected due to lack of required " \
+        "permission.")
 
     @patch("tap_zendesk.discover.LOGGER.warning")
     @patch('tap_zendesk.streams.TalkPhoneNumbers.check_access')
@@ -85,19 +80,9 @@ class TestDiscovery(unittest.TestCase):
     @patch('tap_zendesk.streams.abstracts.Stream.load_metadata', return_value={})
     @patch('tap_zendesk.streams.abstracts.Stream.load_schema', return_value={})
     @patch('singer.resolve_schema_references', return_value={})
-    @patch('requests.get',
-           side_effect=[
-                mocked_get(status_code=200, json={"tickets": [{"id": "t1"}]}), # Response of the 1st get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 2nd get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 3rd get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 4th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 5th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 6th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 7th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 8th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 9th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}) # Response of the 10th get request call
-            ])
+    @patch('requests.get', side_effect=[
+        mocked_get(status_code=403, json={"key1": "val1"}) for _ in range(50)
+    ])
     def test_discovery_handles_403_raise_zenpy_forbidden_error_for_access_token(self, mock_get, mock_resolve_schema_references, mock_load_metadata,
                                 mock_load_schema,mock_load_shared_schema_refs, mocked_sla_policies, mocked_ticket_forms,
                                 mock_users, mock_organizations, mocked_ticket_metric_events, mocked_talk_phone_numbers, mock_logger):
@@ -110,7 +95,7 @@ class TestDiscovery(unittest.TestCase):
         '''
         discover.discover_streams('dummy_client', {'subdomain': 'arp', 'access_token': 'dummy_token', 'start_date':START_DATE})
 
-        expected_call_count = 8
+        expected_call_count = 36
         actual_call_count = mock_get.call_count
         self.assertEqual(expected_call_count, actual_call_count)
 
@@ -131,18 +116,9 @@ class TestDiscovery(unittest.TestCase):
     @patch('tap_zendesk.streams.abstracts.Stream.load_metadata', return_value={})
     @patch('tap_zendesk.streams.abstracts.Stream.load_schema', return_value={})
     @patch('singer.resolve_schema_references', return_value={})
-    @patch('requests.get',
-           side_effect=[
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 1st get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 2nd get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 4th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 5th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 6th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 7th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 8th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 9th get request call
-                # mocked_get(status_code=404, json={"key1": "val1"}) # Response of the 10th get request call
-            ])
+    @patch('requests.get', side_effect=[
+        mocked_get(status_code=403, json={"key1": "val1"}) for _ in range(50)
+    ])
     def test_discovery_handles_403_raise_zenpy_forbidden_error_for_api_token(self, mock_get, mock_resolve_schema_references,
                                 mock_load_metadata, mock_load_schema,mock_load_shared_schema_refs, mocked_sla_policies,
                                 mocked_ticket_forms, mock_users, mock_organizations, mocked_ticket_metric_events, mocked_talk_phone_numbers, mock_logger):
@@ -155,7 +131,7 @@ class TestDiscovery(unittest.TestCase):
         '''
 
         responses = discover.discover_streams('dummy_client', {'subdomain': 'arp', 'access_token': 'dummy_token', 'start_date':START_DATE})
-        expected_call_count = 8
+        expected_call_count = 36
         actual_call_count = mock_get.call_count
         self.assertEqual(expected_call_count, actual_call_count)
 
@@ -215,16 +191,9 @@ class TestDiscovery(unittest.TestCase):
     @patch('tap_zendesk.streams.abstracts.Stream.load_metadata', return_value={})
     @patch('tap_zendesk.streams.abstracts.Stream.load_schema', return_value={})
     @patch('singer.resolve_schema_references', return_value={})
-    @patch('requests.get',
-           side_effect=[
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 1st get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 2nd get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 3rd get request call
-                mocked_get(status_code=400, json={"key1": "val1"}), # Response of the 4th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 5th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 6th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 7th get request call
-            ])
+    @patch('requests.get', side_effect=[
+        mocked_get(status_code=403, json={"key1": "val1"}) for _ in range(50)
+    ])
     def test_discovery_handles_except_403_error_zenpy_module(self, mock_get, mock_resolve_schema_references,
                                 mock_load_metadata, mock_load_schema,mock_load_shared_schema_refs, mocked_sla_policies,
                                 mocked_ticket_forms, mock_users, mock_organizations, mocked_ticket_metric_events, mocked_talk_phone_numbers):
@@ -241,7 +210,7 @@ class TestDiscovery(unittest.TestCase):
             # Verifying the message formed for the custom exception
             self.assertEqual(str(e), expected_error_message)
 
-        expected_call_count = 3
+        expected_call_count = 13
         actual_call_count = mock_get.call_count
         self.assertEqual(expected_call_count, actual_call_count)
 
@@ -255,28 +224,18 @@ class TestDiscovery(unittest.TestCase):
     @patch('tap_zendesk.streams.abstracts.Stream.load_metadata', return_value={})
     @patch('tap_zendesk.streams.abstracts.Stream.load_schema', return_value={})
     @patch('singer.resolve_schema_references', return_value={})
-    @patch('requests.get',
-           side_effect=[
-                mocked_get(status_code=200, json={"tickets": [{"id": "t1"}]}), # Response of the 1st get request call
-                mocked_get(status_code=200, json={"key1": "val1"}), # Response of the 1st get request call
-                mocked_get(status_code=200, json={"key1": "val1"}), # Response of the 1st get request call
-                mocked_get(status_code=200, json={"key1": "val1"}), # Response of the 1st get request call
-                mocked_get(status_code=200, json={"key1": "val1"}), # Response of the 1st get request call
-                mocked_get(status_code=200, json={"key1": "val1"}), # Response of the 1st get request call
-                mocked_get(status_code=200, json={"key1": "val1"}), # Response of the 1st get request call
-                mocked_get(status_code=200, json={"key1": "val1"}), # Response of the 1st get request call
-                mocked_get(status_code=200, json={"key1": "val1"}), # Response of the 1st get request call
-                mocked_get(status_code=200, json={"key1": "val1"}) # Response of the 1st get request call
-            ])
-    def test_discovery_handles_200_response(self, mock_get, mock_resolve_schema_references, 
-                                mock_load_metadata, mock_load_schema,mock_load_shared_schema_refs, mocked_sla_policies, 
+    @patch('requests.get', side_effect=[
+        mocked_get(status_code=200, json={"key1": "val1"}) for _ in range(50)
+    ])
+    def test_discovery_handles_200_response(self, mock_get, mock_resolve_schema_references,
+                                mock_load_metadata, mock_load_schema,mock_load_shared_schema_refs, mocked_sla_policies,
                                 mocked_ticket_forms, mock_users, mock_organizations, mocked_ticket_metric_events, mocked_talk_phone_numbers):
         '''
         Test that discovery mode does not raise any error in case of all streams have read permission
         '''
         discover.discover_streams('dummy_client', {'subdomain': 'arp', 'access_token': 'dummy_token', 'start_date':START_DATE})
 
-        expected_call_count = 8
+        expected_call_count = 36
         actual_call_count = mock_get.call_count
         self.assertEqual(expected_call_count, actual_call_count)
 
@@ -291,19 +250,9 @@ class TestDiscovery(unittest.TestCase):
     @patch('tap_zendesk.streams.abstracts.Stream.load_metadata', return_value={})
     @patch('tap_zendesk.streams.abstracts.Stream.load_schema', return_value={})
     @patch('singer.resolve_schema_references', return_value={})
-    @patch('requests.get',
-           side_effect=[
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 1st get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 2nd get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 3rd get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 4th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 5th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 6th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 7th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 8th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}), # Response of the 9th get request call
-                mocked_get(status_code=403, json={"key1": "val1"}) # Response of the 10th get request call
-            ])
+    @patch('requests.get', side_effect=[
+        mocked_get(status_code=403, json={"key1": "val1"}) for _ in range(50)
+    ])
     def test_discovery_handles_403_for_all_streams_api_token(self, mock_get, mock_resolve_schema_references,
                                 mock_load_metadata, mock_load_schema,mock_load_shared_schema_refs, mocked_sla_policies,
                                 mocked_ticket_forms, mock_users, mock_organizations, mocked_ticket_metric_events, mocked_talk_phone_numbers, mock_logger):


### PR DESCRIPTION
# Description of change
This PR covers sync implementation for streams:
- sessions
- sharing_agreements
- side_conversations_events
- recipient_addresses
- suspended_tickets
- targets
- targets_failures

# Manual QA steps
 - [x]  Discovery: running
 - [ ]  Sync: not running (404 error)
  
# Rollback steps
 - revert this branch
