### PR TITLE
Update ticket_metrics.json

### DIFF
--- a/tap_zendesk/schemas/ticket_metrics.json
+++ b/tap_zendesk/schemas/ticket_metrics.json
@@ -268,6 +268,20 @@
         "string"
       ],
       "format": "date-time"
+    },
+    "reply_time_in_seconds": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "calendar": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        }
+      }
     }
   },
   "type": [


### PR DESCRIPTION
There is a metric for the Message channel that has first_reply_in_seconds in ONLY calendar hours.  This will allow first response time in seconds for "chats" to be captured.

# Description of change
Adds a new metric that exists for Messaging tickets in Zendesk to measure the first reply time in seconds.
<img width="683" height="141" alt="image" src="https://github.com/user-attachments/assets/c8c68165-bc86-4ab4-a2ec-904aa479a227" />


# Manual QA steps
 - validate that the reply_time_in_seconds gets populated on a sync from a Zendesk instance.
 
# Risks
 - minor - field doesn't populate
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
