### PR TITLE
fix: add type definitions to empty schema properties

### DIFF
--- a/tap_zendesk/schemas/shared/metadata.json
+++ b/tap_zendesk/schemas/shared/metadata.json
@@ -4,7 +4,12 @@
     "object"
   ],
   "properties": {
-    "custom": {},
+    "custom": {
+      "type": [
+        "null",
+        "object"
+      ]
+    },
     "trusted": {
       "type": [
         "null",

--- a/tap_zendesk/schemas/sla_policies.json
+++ b/tap_zendesk/schemas/sla_policies.json
@@ -99,7 +99,7 @@
           "priority": { "type": ["null", "string"] },
           "target": { "type": ["null", "integer"] },
           "business_hours": { "type": ["null", "boolean"] },
-          "metric": { }
+          "metric": { "type": ["null", "string"] }
         },
         "type": [
           "null",

--- a/tap_zendesk/schemas/ticket_audits.json
+++ b/tap_zendesk/schemas/ticket_audits.json
@@ -245,7 +245,12 @@
               "string"
             ]
           },
-          "transcription_visible": {},
+          "transcription_visible": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
           "trusted": {
             "type": [
               "null",
@@ -505,7 +510,12 @@
         "object"
       ],
       "properties": {
-        "custom": {},
+        "custom": {
+          "type": [
+            "null",
+            "object"
+          ]
+        },
         "trusted": {
           "type": [
             "null",

--- a/tap_zendesk/schemas/ticket_fields.json
+++ b/tap_zendesk/schemas/ticket_fields.json
@@ -183,7 +183,12 @@
         "null",
         "array"
       ],
-      "items": {}
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ]
+      }
     },
     "sub_type_id": {
       "type": [

--- a/tap_zendesk/schemas/tickets.json
+++ b/tap_zendesk/schemas/tickets.json
@@ -149,7 +149,7 @@
               "integer"
             ]
           },
-          "value": { }
+          "value": { "type": ["null", "string", "boolean", "integer", "number", "array", "object"] }
         },
         "type": [
           "null",


### PR DESCRIPTION
Empty schema definitions ({}) cause Singer targets like target-postgres to silently skip fields with 'WARNING Empty definition for <field_name>'.

Fixed fields:
- shared/metadata.json: custom -> type: [null, object]
- ticket_audits.json: transcription_visible -> type: [null, boolean]
- ticket_audits.json: metadata.custom -> type: [null, object]
- ticket_fields.json: system_field_options.items -> type: [null, object]
- sla_policies.json: policy_metrics.metric -> type: [null, string]
- tickets.json: custom_fields.value -> permissive type union

# Description of change
(write a short description or paste a link to JIRA)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
