### PR TITLE
Add OAuth refresh token support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.0
+  * Handle Oauth token expiry [#182](https://github.com/singer-io/tap-zendesk/pull/182)
+  * Implement dev mode
+
 ## 2.7.2
   * Update aiohttp for twistlock [#178](https://github.com/singer-io/tap-zendesk/pull/178)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='2.7.2',
+      version='2.8.0',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -13,6 +13,7 @@ from singer import metadata, metrics as singer_metrics
 import backoff
 from tap_zendesk import metrics as zendesk_metrics
 from tap_zendesk.discover import discover_streams
+from tap_zendesk.oauth import refresh_credentials
 from tap_zendesk.streams import STREAMS
 from tap_zendesk.sync import sync_stream
 
@@ -215,12 +216,20 @@ def get_session(config):
 def main():
     parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
 
+    dev_mode = getattr(parsed_args, 'dev', False)
+    if dev_mode:
+        LOGGER.warning("Executing Tap in Dev mode")
+
     # Set request timeout to config param `request_timeout` value.
     config_request_timeout = parsed_args.config.get('request_timeout')
     if config_request_timeout and float(config_request_timeout):
         request_timeout = float(config_request_timeout)
     else:
         request_timeout = REQUEST_TIMEOUT  # If value is 0, "0", "" or not passed then it sets default to 300 seconds.
+
+    config_path = parsed_args.config_path
+    parsed_args.config = refresh_credentials(parsed_args.config, config_path, dev_mode=dev_mode)
+
     # OAuth has precedence
     creds = oauth_auth(parsed_args) or api_token_auth(parsed_args)
     session = get_session(parsed_args.config)

--- a/tap_zendesk/oauth.py
+++ b/tap_zendesk/oauth.py
@@ -1,13 +1,21 @@
 """
+Handles refreshing access_token and refresh_token according to Zendesk's
+OAuth token expiration policy:
+  - access_token: max 172,800 seconds (2 days / 48 hours)
+
 On every session, new access_token and refresh_token values are generated
 via the refresh_token grant type, and the updated tokens are persisted back to the config file.
 
 When the access_token and refresh_token are renewed, the old tokens are invalidated and cannot be used again.
 
 Backward compatibility: if refresh_token is absent from the config, token refresh is skipped.
+
+Zendesk docs: https://developer.zendesk.com/api-reference/ticketing/oauth/grant_type_tokens/
 """
 
 import json
+import datetime
+from logging import config
 import requests
 import singer
 from tap_zendesk.http import ZendeskError
@@ -19,6 +27,34 @@ TOKEN_REFRESH_URL = "https://{subdomain}.zendesk.com/oauth/tokens"
 
 # access_token validity: 48 hours (172800 seconds)
 ACCESS_TOKEN_EXPIRES_IN = 172800
+
+# Renew access_token 30 minutes before its expiry
+ACCESS_TOKEN_RENEWAL_BUFFER_MINUTES = 30
+
+def _is_access_token_expiring(config):
+    """
+    Check whether the access_token is within 30 minutes of its expiry.
+    If 'access_token_expires_at' is not stored in config, assume it needs refreshing.
+    """
+    expires_at_str = config.get('access_token_expires_at')
+    if not expires_at_str:
+        LOGGER.info("No 'access_token_expires_at' in config. Will refresh the access_token.")
+        return True
+
+    try:
+        expires_at = datetime.datetime.fromisoformat(expires_at_str)
+    except (ValueError, TypeError):
+        LOGGER.warning("Invalid 'access_token_expires_at': %s. Will refresh.", expires_at_str)
+        return True
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    buffer = datetime.timedelta(minutes=ACCESS_TOKEN_RENEWAL_BUFFER_MINUTES)
+
+    if now >= (expires_at - buffer):
+        LOGGER.info("Access token expiring soon (expires_at: %s). Refreshing it now.", expires_at_str)
+        return True
+
+    return False
 
 def _refresh_access_token(config):
     """
@@ -89,10 +125,18 @@ def refresh_credentials(config, config_path, dev_mode=False):
     if 'refresh_token' not in config:
         return config
 
+    if not _is_access_token_expiring(config):
+        return config
+
     token_data = _refresh_access_token(config)
 
     config['access_token'] = token_data['access_token']
     config['refresh_token'] = token_data['refresh_token']
+
+    # Compute and store access_token_expires_at
+    expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+        seconds=ACCESS_TOKEN_EXPIRES_IN)
+    config['access_token_expires_at'] = expires_at.isoformat()
 
     # Persist updated tokens back to config file
     _write_config(config_path, config)

--- a/tap_zendesk/oauth.py
+++ b/tap_zendesk/oauth.py
@@ -1,0 +1,141 @@
+"""
+OAuth token management for Zendesk API.
+
+Handles refreshing access_token and refresh_token according to Zendesk's
+OAuth token expiration policy:
+  - access_token: max 172,800 seconds (2 days / 48 hours)
+  - refresh_token: max 7,776,000 seconds (90 days)
+
+Zendesk docs: https://developer.zendesk.com/api-reference/ticketing/oauth/grant_type_tokens/
+
+On every session a new access_token is generated via the refresh_token grant type.
+The refresh_token is refreshed 1 day before its expiry and the updated tokens
+are persisted back to the config file.
+
+Backward compatible: when refresh_token is absent from config, nothing happens.
+"""
+
+import json
+import datetime
+
+import requests
+import singer
+
+LOGGER = singer.get_logger()
+
+# Zendesk OAuth token endpoint
+TOKEN_REFRESH_URL = "https://{subdomain}.zendesk.com/oauth/tokens"
+
+# access_token validity: 48 hours (172800 seconds)
+ACCESS_TOKEN_EXPIRES_IN = 172800
+
+# refresh_token validity: 90 days (7776000 seconds)
+REFRESH_TOKEN_EXPIRES_IN = 7776000
+
+# Renew refresh_token 1 day before its expiry
+REFRESH_TOKEN_RENEWAL_BUFFER_DAYS = 1
+
+def _is_refresh_token_expiring(config):
+    """
+    Check whether the refresh_token is within 1 day of its expiry.
+    If 'refresh_token_expires_at' is not stored in config, assume it needs refreshing.
+    """
+    expires_at_str = config.get('refresh_token_expires_at')
+    if not expires_at_str:
+        LOGGER.info("No 'refresh_token_expires_at' in config. Will refresh the refresh_token.")
+        return True
+
+    try:
+        expires_at = datetime.datetime.fromisoformat(expires_at_str)
+    except (ValueError, TypeError):
+        LOGGER.warning("Invalid 'refresh_token_expires_at': %s. Will refresh.", expires_at_str)
+        return True
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    buffer = datetime.timedelta(days=REFRESH_TOKEN_RENEWAL_BUFFER_DAYS)
+
+    if now >= (expires_at - buffer):
+        LOGGER.info("Refresh token expiring soon (expires_at: %s). Refreshing it now.", expires_at_str)
+        return True
+
+    return False
+
+
+def _refresh_access_token(config):
+    """
+    POST to Zendesk /oauth/tokens with grant_type=refresh_token.
+    Returns the full token response dict.
+    """
+    subdomain = config['subdomain']
+    url = TOKEN_REFRESH_URL.format(subdomain=subdomain)
+
+    payload = {
+        'grant_type': 'refresh_token',
+        'refresh_token': config['refresh_token'],
+        'client_id': config['client_id'],
+        'client_secret': config['client_secret'],
+        'scope': 'read',
+        'expires_in': ACCESS_TOKEN_EXPIRES_IN,
+        'refresh_token_expires_in': REFRESH_TOKEN_EXPIRES_IN
+    }
+
+    response = requests.post(url, json=payload, timeout=60)
+
+    if response.status_code != 200:
+        raise Exception(
+            "OAuth token refresh failed. HTTP {}: {}".format(
+                response.status_code, response.text))
+
+    token_data = response.json()
+    LOGGER.info("Successfully refreshed access_token.")
+    return token_data
+
+
+def _write_config(config_path, config):
+    """
+    Write updated config back to the config file.
+    """
+    with open(config_path, encoding='utf-8') as file:
+        disk_config = json.load(file)
+
+    disk_config['refresh_token'] = config['refresh_token']
+    disk_config['access_token'] = config['access_token']
+    disk_config['refresh_token_expires_at'] = config['refresh_token_expires_at']
+
+    with open(config_path, 'w', encoding='utf-8') as file:
+        json.dump(disk_config, file, indent=2)
+
+
+def refresh_credentials(config, config_path, dev_mode=False):
+    """
+    Main entry point for OAuth credential management.
+    """
+
+    # api_token/email auth doesn't use access_token/refresh_token, so skip
+    if 'access_token' not in config:
+        return config
+
+    # Backward compatibility: no refresh_token means legacy flow — do nothing
+    if 'refresh_token' not in config:
+        return config
+
+    if dev_mode:
+        return config
+
+    if not _is_refresh_token_expiring(config):
+        return config
+
+    token_data = _refresh_access_token(config)
+
+    config['access_token'] = token_data['access_token']
+    config['refresh_token'] = token_data['refresh_token']
+
+    # Compute and store refresh_token_expires_at
+    expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+        seconds=REFRESH_TOKEN_EXPIRES_IN)
+    config['refresh_token_expires_at'] = expires_at.isoformat()
+
+    # Persist updated tokens back to config file
+    _write_config(config_path, config)
+
+    return config

--- a/tap_zendesk/oauth.py
+++ b/tap_zendesk/oauth.py
@@ -15,7 +15,6 @@ Zendesk docs: https://developer.zendesk.com/api-reference/ticketing/oauth/grant_
 
 import json
 import datetime
-from logging import config
 import requests
 import singer
 from tap_zendesk.http import ZendeskError
@@ -31,12 +30,12 @@ ACCESS_TOKEN_EXPIRES_IN = 172800
 # Renew access_token 30 minutes before its expiry
 ACCESS_TOKEN_RENEWAL_BUFFER_MINUTES = 30
 
-def _is_access_token_expiring(config):
+def _is_access_token_expiring(_config):
     """
     Check whether the access_token is within 30 minutes of its expiry.
     If 'access_token_expires_at' is not stored in config, assume it needs refreshing.
     """
-    expires_at_str = config.get('access_token_expires_at')
+    expires_at_str = _config.get('access_token_expires_at')
     if not expires_at_str:
         LOGGER.info("No 'access_token_expires_at' in config. Will refresh the access_token.")
         return True
@@ -56,19 +55,19 @@ def _is_access_token_expiring(config):
 
     return False
 
-def _refresh_access_token(config):
+def _refresh_access_token(_config):
     """
     POST to Zendesk /oauth/tokens with grant_type=refresh_token.
     Returns the full token response dict.
     """
-    subdomain = config['subdomain']
+    subdomain = _config['subdomain']
     url = TOKEN_REFRESH_URL.format(subdomain=subdomain)
 
     payload = {
         'grant_type': 'refresh_token',
-        'refresh_token': config['refresh_token'],
-        'client_id': config['client_id'],
-        'client_secret': config['client_secret'],
+        'refresh_token': _config['refresh_token'],
+        'client_id': _config['client_id'],
+        'client_secret': _config['client_secret'],
         'expires_in': ACCESS_TOKEN_EXPIRES_IN
     }
 
@@ -95,50 +94,50 @@ def _refresh_access_token(config):
     return token_data
 
 
-def _write_config(config_path, config):
+def _write_config(config_path, _config):
     """
     Write updated config back to the config file.
     """
     with open(config_path, encoding='utf-8') as file:
         disk_config = json.load(file)
 
-    disk_config['refresh_token'] = config['refresh_token']
-    disk_config['access_token'] = config['access_token']
+    disk_config['refresh_token'] = _config['refresh_token']
+    disk_config['access_token'] = _config['access_token']
 
     with open(config_path, 'w', encoding='utf-8') as file:
         json.dump(disk_config, file, indent=2)
 
 
-def refresh_credentials(config, config_path, dev_mode=False):
+def refresh_credentials(_config, config_path, dev_mode=False):
     """
     Main entry point for OAuth credential management.
     """
 
     if dev_mode:
-        return config
+        return _config
 
     # api_token/email auth doesn't use access_token/refresh_token, so skip
-    if 'access_token' not in config:
-        return config
+    if 'access_token' not in _config:
+        return _config
 
     # Backward compatibility: no refresh_token means legacy flow — do nothing
-    if 'refresh_token' not in config:
-        return config
+    if 'refresh_token' not in _config:
+        return _config
 
-    if not _is_access_token_expiring(config):
-        return config
+    if not _is_access_token_expiring(_config):
+        return _config
 
-    token_data = _refresh_access_token(config)
+    token_data = _refresh_access_token(_config)
 
-    config['access_token'] = token_data['access_token']
-    config['refresh_token'] = token_data['refresh_token']
+    _config['access_token'] = token_data['access_token']
+    _config['refresh_token'] = token_data['refresh_token']
 
     # Compute and store access_token_expires_at
     expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
         seconds=ACCESS_TOKEN_EXPIRES_IN)
-    config['access_token_expires_at'] = expires_at.isoformat()
+    _config['access_token_expires_at'] = expires_at.isoformat()
 
     # Persist updated tokens back to config file
-    _write_config(config_path, config)
+    _write_config(config_path, _config)
 
-    return config
+    return _config

--- a/tap_zendesk/oauth.py
+++ b/tap_zendesk/oauth.py
@@ -1,8 +1,9 @@
 """
 Handles refreshing access_token and refresh_token for Zendesk OAuth.
 
-On every session, a lightweight credential check (GET /api/v2/users/me) is
-performed.  If the API returns HTTP 401 (token expired / revoked), new
+On every session, the current token is inspected via
+GET /api/v2/oauth/tokens/current.json.  If the token will expire within
+a 3-hour buffer window (Buffer for ongoing sync), new
 access_token and refresh_token values are obtained via the refresh_token
 grant type and persisted back to the config file.
 
@@ -16,6 +17,8 @@ Zendesk docs:
 """
 
 import json
+import time
+from datetime import datetime
 import requests
 import singer
 from tap_zendesk.http import ZendeskError
@@ -25,19 +28,26 @@ LOGGER = singer.get_logger()
 # Zendesk OAuth token endpoint
 TOKEN_REFRESH_URL = "https://{subdomain}.zendesk.com/oauth/tokens"
 
-# Lightweight endpoint used to verify that the current access_token is valid
-CREDENTIAL_CHECK_URL = "https://{subdomain}.zendesk.com/api/v2/users/me.json"
+# Endpoint to inspect the current OAuth token
+TOKEN_INFO_URL = "https://{subdomain}.zendesk.com/api/v2/oauth/tokens/current.json"
+
+# Refresh the token if it expires within this many seconds (3 hours)
+EXPIRY_BUFFER_SECONDS = 10800
 
 
 def _is_token_expired(_config):
     """
-    Make a lightweight API call to Zendesk to check whether the current
-    access_token is still valid.
+    Call GET /api/v2/oauth/tokens/current.json to retrieve the token's
+    ``expires_at`` (Unix timestamp).
 
-    Returns True if the token is expired/invalid (HTTP 401), False otherwise.
+    Returns True when:
+      - The API returns a non-200 status (token already invalid/revoked).
+      - The token will expire within the EXPIRY_BUFFER_SECONDS window.
+
+    Returns False if the token is still valid beyond the buffer.
     """
     subdomain = _config['subdomain']
-    url = CREDENTIAL_CHECK_URL.format(subdomain=subdomain)
+    url = TOKEN_INFO_URL.format(subdomain=subdomain)
     headers = {
         'Authorization': 'Bearer {}'.format(_config['access_token']),
         'Accept': 'application/json',
@@ -46,13 +56,30 @@ def _is_token_expired(_config):
     try:
         response = requests.get(url, headers=headers, timeout=60)
     except requests.RequestException as exc:
-        LOGGER.warning("Credential check request failed: %s. Will attempt token refresh.", exc)
+        LOGGER.warning("Token info request failed: %s. Will attempt token refresh.", exc)
         return True
 
-    if response.status_code == 200:
+    if response.status_code != 200:
+        LOGGER.info("Token info endpoint returned HTTP %s. Token needs to be refreshed.", response.status_code)
+        return True
+
+    token_info = response.json()['token']
+    expires_at = token_info['expires_at']
+
+    # Token has no expiration date. Means it does not expire.
+    if not expires_at:
         return False
 
-    return True
+    now = time.time()
+    # expires_at is an ISO 8601 string (e.g. "2026-04-22T06:32:35Z"); convert to Unix timestamp
+    expires_at_ts = datetime.fromisoformat(expires_at).timestamp()
+    remaining = expires_at_ts - now
+
+    if remaining <= EXPIRY_BUFFER_SECONDS:
+        LOGGER.info("Token will expire in %.0f seconds. Will attempt token refresh.", remaining)
+        return True
+
+    return False
 
 
 def _refresh_access_token(_config):

--- a/tap_zendesk/oauth.py
+++ b/tap_zendesk/oauth.py
@@ -32,8 +32,9 @@ TOKEN_REFRESH_URL = "https://{subdomain}.zendesk.com/oauth/tokens"
 TOKEN_INFO_URL = "https://{subdomain}.zendesk.com/api/v2/oauth/tokens/current.json"
 
 # Refresh the token if it expires within this many seconds (3 hours)
-EXPIRY_BUFFER_SECONDS = 10800
+EXPIRY_BUFFER_SECONDS = 3 * 60 * 60
 
+ACCESS_TOKEN_VALIDITY_SECONDS = 48 * 60 * 60
 
 def _is_token_expired(_config):
     """
@@ -95,14 +96,13 @@ def _refresh_access_token(_config):
         'refresh_token': _config['refresh_token'],
         'client_id': _config['client_id'],
         'client_secret': _config['client_secret'],
+        'expires_in': ACCESS_TOKEN_VALIDITY_SECONDS
     }
 
     response = requests.post(url, json=payload, timeout=60)
 
     if response.status_code != 200:
-        raise ZendeskError(
-            "OAuth token refresh failed. HTTP {}: {}".format(
-                response.status_code, response.text))
+        raise ZendeskError("Failed to refresh access token. Refresh token might have expired or been revoked. Please re-authorize the connection.")
 
     token_data = response.json()
 

--- a/tap_zendesk/oauth.py
+++ b/tap_zendesk/oauth.py
@@ -1,17 +1,10 @@
 """
-OAuth token management for Zendesk API.
+On every session, new access_token and refresh_token values are generated
+via the refresh_token grant type, and the updated tokens are persisted back to the config file.
 
-Handles refreshing access_token and refresh_token according to Zendesk's
-OAuth token expiration policy:
-  - access_token: max 172,800 seconds (2 days / 48 hours)
+When the access_token and refresh_token are renewed, the old tokens are invalidated and cannot be used again.
 
-Zendesk docs: https://developer.zendesk.com/api-reference/ticketing/oauth/grant_type_tokens/
-
-On every session a new access_token and refresh_token is generated 
-via the refresh_token grant type and the updated tokens are persisted back to the config file.
-
-When renew access_token and refresh_token, the old tokens are invalidated and cannot be used again.
-Backward compatible: when refresh_token is absent from config, nothing happens.
+Backward compatibility: if refresh_token is absent from the config, token refresh is skipped.
 """
 
 import json
@@ -51,6 +44,17 @@ def _refresh_access_token(config):
                 response.status_code, response.text))
 
     token_data = response.json()
+
+   # Validate that the expected fields are present in the token response
+    missing_fields = [
+        field for field in ("access_token", "refresh_token")
+        if field not in token_data
+    ]
+    if missing_fields:
+        raise ZendeskError(
+            "OAuth token refresh response missing required field(s) {}.".format(", ".join(missing_fields))
+        )
+
     LOGGER.info("Successfully refreshed access_token.")
     return token_data
 

--- a/tap_zendesk/oauth.py
+++ b/tap_zendesk/oauth.py
@@ -1,20 +1,21 @@
 """
-Handles refreshing access_token and refresh_token according to Zendesk's
-OAuth token expiration policy:
-  - access_token: max 172,800 seconds (2 days / 48 hours)
+Handles refreshing access_token and refresh_token for Zendesk OAuth.
 
-On every session, new access_token and refresh_token values are generated
-via the refresh_token grant type, and the updated tokens are persisted back to the config file.
+On every session, a lightweight credential check (GET /api/v2/users/me) is
+performed.  If the API returns HTTP 401 (token expired / revoked), new
+access_token and refresh_token values are obtained via the refresh_token
+grant type and persisted back to the config file.
 
-When the access_token and refresh_token are renewed, the old tokens are invalidated and cannot be used again.
+When the tokens are renewed the old ones are invalidated by Zendesk.
 
-Backward compatibility: if refresh_token is absent from the config, token refresh is skipped.
+Backward compatibility: if refresh_token is absent from the config, token
+refresh is skipped.
 
-Zendesk docs: https://developer.zendesk.com/api-reference/ticketing/oauth/grant_type_tokens/
+Zendesk docs:
+  https://developer.zendesk.com/api-reference/ticketing/oauth/grant_type_tokens/
 """
 
 import json
-import datetime
 import requests
 import singer
 from tap_zendesk.http import ZendeskError
@@ -24,36 +25,35 @@ LOGGER = singer.get_logger()
 # Zendesk OAuth token endpoint
 TOKEN_REFRESH_URL = "https://{subdomain}.zendesk.com/oauth/tokens"
 
-# access_token validity: 48 hours (172800 seconds)
-ACCESS_TOKEN_EXPIRES_IN = 172800
+# Lightweight endpoint used to verify that the current access_token is valid
+CREDENTIAL_CHECK_URL = "https://{subdomain}.zendesk.com/api/v2/users/me.json"
 
-# Renew access_token 30 minutes before its expiry
-ACCESS_TOKEN_RENEWAL_BUFFER_MINUTES = 30
 
-def _is_access_token_expiring(_config):
+def _is_token_expired(_config):
     """
-    Check whether the access_token is within 30 minutes of its expiry.
-    If 'access_token_expires_at' is not stored in config, assume it needs refreshing.
+    Make a lightweight API call to Zendesk to check whether the current
+    access_token is still valid.
+
+    Returns True if the token is expired/invalid (HTTP 401), False otherwise.
     """
-    expires_at_str = _config.get('access_token_expires_at')
-    if not expires_at_str:
-        LOGGER.info("No 'access_token_expires_at' in config. Will refresh the access_token.")
-        return True
+    subdomain = _config['subdomain']
+    url = CREDENTIAL_CHECK_URL.format(subdomain=subdomain)
+    headers = {
+        'Authorization': 'Bearer {}'.format(_config['access_token']),
+        'Accept': 'application/json',
+    }
 
     try:
-        expires_at = datetime.datetime.fromisoformat(expires_at_str)
-    except (ValueError, TypeError):
-        LOGGER.warning("Invalid 'access_token_expires_at': %s. Will refresh.", expires_at_str)
+        response = requests.get(url, headers=headers, timeout=60)
+    except requests.RequestException as exc:
+        LOGGER.warning("Credential check request failed: %s. Will attempt token refresh.", exc)
         return True
 
-    now = datetime.datetime.now(datetime.timezone.utc)
-    buffer = datetime.timedelta(minutes=ACCESS_TOKEN_RENEWAL_BUFFER_MINUTES)
+    if response.status_code == 200:
+        return False
 
-    if now >= (expires_at - buffer):
-        LOGGER.info("Access token expiring soon (expires_at: %s). Refreshing it now.", expires_at_str)
-        return True
+    return True
 
-    return False
 
 def _refresh_access_token(_config):
     """
@@ -68,7 +68,6 @@ def _refresh_access_token(_config):
         'refresh_token': _config['refresh_token'],
         'client_id': _config['client_id'],
         'client_secret': _config['client_secret'],
-        'expires_in': ACCESS_TOKEN_EXPIRES_IN
     }
 
     response = requests.post(url, json=payload, timeout=60)
@@ -80,23 +79,13 @@ def _refresh_access_token(_config):
 
     token_data = response.json()
 
-   # Validate that the expected fields are present in the token response
-    missing_fields = [
-        field for field in ("access_token", "refresh_token")
-        if field not in token_data
-    ]
-    if missing_fields:
-        raise ZendeskError(
-            "OAuth token refresh response missing required field(s) {}.".format(", ".join(missing_fields))
-        )
-
-    LOGGER.info("Successfully refreshed access_token.")
+    LOGGER.info("Successfully refreshed access_token and refresh_token.")
     return token_data
 
 
 def _write_config(config_path, _config):
     """
-    Write updated config back to the config file.
+    Write updated tokens back to the config file.
     """
     with open(config_path, encoding='utf-8') as file:
         disk_config = json.load(file)
@@ -124,18 +113,13 @@ def refresh_credentials(_config, config_path, dev_mode=False):
     if 'refresh_token' not in _config:
         return _config
 
-    if not _is_access_token_expiring(_config):
+    if not _is_token_expired(_config):
         return _config
 
     token_data = _refresh_access_token(_config)
 
     _config['access_token'] = token_data['access_token']
     _config['refresh_token'] = token_data['refresh_token']
-
-    # Compute and store access_token_expires_at
-    expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
-        seconds=ACCESS_TOKEN_EXPIRES_IN)
-    _config['access_token_expires_at'] = expires_at.isoformat()
 
     # Persist updated tokens back to config file
     _write_config(config_path, _config)

--- a/tap_zendesk/oauth.py
+++ b/tap_zendesk/oauth.py
@@ -36,16 +36,16 @@ EXPIRY_BUFFER_SECONDS = 3 * 60 * 60
 
 ACCESS_TOKEN_VALIDITY_SECONDS = 48 * 60 * 60
 
-def _is_token_expired(_config):
+def is_token_valid(_config):
     """
     Call GET /api/v2/oauth/tokens/current.json to retrieve the token's
     ``expires_at`` (Unix timestamp).
 
-    Returns True when:
+    Returns False when:
       - The API returns a non-200 status (token already invalid/revoked).
       - The token will expire within the EXPIRY_BUFFER_SECONDS window.
 
-    Returns False if the token is still valid beyond the buffer.
+    Returns True if the token is still valid beyond the buffer.
     """
     subdomain = _config['subdomain']
     url = TOKEN_INFO_URL.format(subdomain=subdomain)
@@ -58,18 +58,18 @@ def _is_token_expired(_config):
         response = requests.get(url, headers=headers, timeout=60)
     except requests.RequestException as exc:
         LOGGER.warning("Token info request failed: %s. Will attempt token refresh.", exc)
-        return True
+        return False
 
     if response.status_code != 200:
         LOGGER.info("Token info endpoint returned HTTP %s. Token needs to be refreshed.", response.status_code)
-        return True
+        return False
 
     token_info = response.json()['token']
     expires_at = token_info['expires_at']
 
     # Token has no expiration date. Means it does not expire.
     if not expires_at:
-        return False
+        return True
 
     now = time.time()
     # expires_at is an ISO 8601 string (e.g. "2026-04-22T06:32:35Z"); convert to Unix timestamp
@@ -78,9 +78,9 @@ def _is_token_expired(_config):
 
     if remaining <= EXPIRY_BUFFER_SECONDS:
         LOGGER.info("Token will expire in %.0f seconds. Will attempt token refresh.", remaining)
-        return True
+        return False
 
-    return False
+    return True
 
 
 def _refresh_access_token(_config):
@@ -140,7 +140,7 @@ def refresh_credentials(_config, config_path, dev_mode=False):
     if 'refresh_token' not in _config:
         return _config
 
-    if not _is_token_expired(_config):
+    if is_token_valid(_config):
         return _config
 
     token_data = _refresh_access_token(_config)

--- a/tap_zendesk/oauth.py
+++ b/tap_zendesk/oauth.py
@@ -4,22 +4,20 @@ OAuth token management for Zendesk API.
 Handles refreshing access_token and refresh_token according to Zendesk's
 OAuth token expiration policy:
   - access_token: max 172,800 seconds (2 days / 48 hours)
-  - refresh_token: max 7,776,000 seconds (90 days)
 
 Zendesk docs: https://developer.zendesk.com/api-reference/ticketing/oauth/grant_type_tokens/
 
-On every session a new access_token is generated via the refresh_token grant type.
-The refresh_token is refreshed 1 day before its expiry and the updated tokens
-are persisted back to the config file.
+On every session a new access_token and refresh_token is generated 
+via the refresh_token grant type and the updated tokens are persisted back to the config file.
 
+When renew access_token and refresh_token, the old tokens are invalidated and cannot be used again.
 Backward compatible: when refresh_token is absent from config, nothing happens.
 """
 
 import json
-import datetime
-
 import requests
 import singer
+from tap_zendesk.http import ZendeskError
 
 LOGGER = singer.get_logger()
 
@@ -28,38 +26,6 @@ TOKEN_REFRESH_URL = "https://{subdomain}.zendesk.com/oauth/tokens"
 
 # access_token validity: 48 hours (172800 seconds)
 ACCESS_TOKEN_EXPIRES_IN = 172800
-
-# refresh_token validity: 90 days (7776000 seconds)
-REFRESH_TOKEN_EXPIRES_IN = 7776000
-
-# Renew refresh_token 1 day before its expiry
-REFRESH_TOKEN_RENEWAL_BUFFER_DAYS = 1
-
-def _is_refresh_token_expiring(config):
-    """
-    Check whether the refresh_token is within 1 day of its expiry.
-    If 'refresh_token_expires_at' is not stored in config, assume it needs refreshing.
-    """
-    expires_at_str = config.get('refresh_token_expires_at')
-    if not expires_at_str:
-        LOGGER.info("No 'refresh_token_expires_at' in config. Will refresh the refresh_token.")
-        return True
-
-    try:
-        expires_at = datetime.datetime.fromisoformat(expires_at_str)
-    except (ValueError, TypeError):
-        LOGGER.warning("Invalid 'refresh_token_expires_at': %s. Will refresh.", expires_at_str)
-        return True
-
-    now = datetime.datetime.now(datetime.timezone.utc)
-    buffer = datetime.timedelta(days=REFRESH_TOKEN_RENEWAL_BUFFER_DAYS)
-
-    if now >= (expires_at - buffer):
-        LOGGER.info("Refresh token expiring soon (expires_at: %s). Refreshing it now.", expires_at_str)
-        return True
-
-    return False
-
 
 def _refresh_access_token(config):
     """
@@ -74,15 +40,13 @@ def _refresh_access_token(config):
         'refresh_token': config['refresh_token'],
         'client_id': config['client_id'],
         'client_secret': config['client_secret'],
-        'scope': 'read',
-        'expires_in': ACCESS_TOKEN_EXPIRES_IN,
-        'refresh_token_expires_in': REFRESH_TOKEN_EXPIRES_IN
+        'expires_in': ACCESS_TOKEN_EXPIRES_IN
     }
 
     response = requests.post(url, json=payload, timeout=60)
 
     if response.status_code != 200:
-        raise Exception(
+        raise ZendeskError(
             "OAuth token refresh failed. HTTP {}: {}".format(
                 response.status_code, response.text))
 
@@ -100,7 +64,6 @@ def _write_config(config_path, config):
 
     disk_config['refresh_token'] = config['refresh_token']
     disk_config['access_token'] = config['access_token']
-    disk_config['refresh_token_expires_at'] = config['refresh_token_expires_at']
 
     with open(config_path, 'w', encoding='utf-8') as file:
         json.dump(disk_config, file, indent=2)
@@ -111,6 +74,9 @@ def refresh_credentials(config, config_path, dev_mode=False):
     Main entry point for OAuth credential management.
     """
 
+    if dev_mode:
+        return config
+
     # api_token/email auth doesn't use access_token/refresh_token, so skip
     if 'access_token' not in config:
         return config
@@ -119,21 +85,10 @@ def refresh_credentials(config, config_path, dev_mode=False):
     if 'refresh_token' not in config:
         return config
 
-    if dev_mode:
-        return config
-
-    if not _is_refresh_token_expiring(config):
-        return config
-
     token_data = _refresh_access_token(config)
 
     config['access_token'] = token_data['access_token']
     config['refresh_token'] = token_data['refresh_token']
-
-    # Compute and store refresh_token_expires_at
-    expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
-        seconds=REFRESH_TOKEN_EXPIRES_IN)
-    config['refresh_token_expires_at'] = expires_at.isoformat()
 
     # Persist updated tokens back to config file
     _write_config(config_path, config)

--- a/test/test_all_streams.py
+++ b/test/test_all_streams.py
@@ -49,7 +49,7 @@ class ZendeskAllStreams(ZendeskTest):
         # Zenpy client credentials to connect to API
         creds = {
             'email': 'dev@stitchdata.com',
-            'password': os.getenv('TAP_ZENDESK_API_PASSWORD'),
+            'token': os.getenv('TAP_ZENDESK_API_TOKEN'),
             'subdomain': self.get_properties()['subdomain'],
         }
 
@@ -79,7 +79,7 @@ class ZendeskAllStreams(ZendeskTest):
         # Zenpy client credentials to connect to API
         creds = {
             'email': 'dev@stitchdata.com',
-            'password': os.getenv('TAP_ZENDESK_API_PASSWORD'),
+            'token': os.getenv('TAP_ZENDESK_API_TOKEN'),
             'subdomain': self.get_properties()['subdomain'],
         }
 

--- a/test/unittests/test_oauth.py
+++ b/test/unittests/test_oauth.py
@@ -1,12 +1,10 @@
-import datetime
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from tap_zendesk.oauth import (
     refresh_credentials,
     _refresh_access_token,
-    ACCESS_TOKEN_EXPIRES_IN,
-    _is_access_token_expiring
+    _is_token_expired,
 )
 from tap_zendesk.http import ZendeskError
 
@@ -107,18 +105,16 @@ class TestRefreshAccessTokenAPI(unittest.TestCase):
             'access_token': 'fresh_at',
             'token_type': 'bearer',
             'refresh_token': 'fresh_rt',
-            'expires_in': ACCESS_TOKEN_EXPIRES_IN
         }
         mock_post.return_value = MockResponse(200, token_resp)
         result = _refresh_access_token(self.BASE_CONFIG)
         self.assertEqual(result['access_token'], 'fresh_at')
         self.assertEqual(result['refresh_token'], 'fresh_rt')
-        self.assertEqual(result['expires_in'], ACCESS_TOKEN_EXPIRES_IN)
-    
+
         url = mock_post.call_args[0][0]
         self.assertEqual(url, 'https://acme.zendesk.com/oauth/tokens')
 
-    # --- 200 OK: verify request payload ---
+    # --- 200 OK: verify request payload (no expires_in) ---
     @patch('tap_zendesk.oauth.requests.post')
     def test_200_correct_payload(self, mock_post):
         mock_post.return_value = MockResponse(200, {
@@ -130,8 +126,7 @@ class TestRefreshAccessTokenAPI(unittest.TestCase):
         self.assertEqual(payload['refresh_token'], 'old_rt')
         self.assertEqual(payload['client_id'], 'cid')
         self.assertEqual(payload['client_secret'], 'cs')
-        self.assertEqual(payload['expires_in'], ACCESS_TOKEN_EXPIRES_IN)
-
+        self.assertNotIn('expires_in', payload)
 
     # --- 400 Bad Request ---
     @patch('tap_zendesk.oauth.requests.post')
@@ -141,49 +136,102 @@ class TestRefreshAccessTokenAPI(unittest.TestCase):
             _refresh_access_token(self.BASE_CONFIG)
         self.assertIn('400', str(ctx.exception))
 
+
 # ===========================================================================
-# 4. _is_access_token_expiring — DATE BOUNDARY CONDITIONS
+# 4. _is_token_expired — CREDENTIAL CHECK API CALL
 # ===========================================================================
-class TestIsAccessTokenExpiring(unittest.TestCase):
-    """All edge cases for expiry checking."""
+class TestIsTokenExpired(unittest.TestCase):
+    """Credential check via GET /api/v2/users/me.json."""
 
-    def test_missing_key_returns_true(self):
-        self.assertTrue(_is_access_token_expiring({}))
+    BASE_CONFIG = {
+        'subdomain': 'acme',
+        'access_token': 'some_at',
+    }
 
-    def test_none_value_returns_true(self):
-        self.assertTrue(_is_access_token_expiring({'access_token_expires_at': None}))
+    @patch('tap_zendesk.oauth.requests.get')
+    def test_200_token_valid(self, mock_get):
+        """200 from /api/v2/users/me means token is valid."""
+        mock_get.return_value = MockResponse(200, {'user': {'id': 1}})
+        self.assertFalse(_is_token_expired(self.BASE_CONFIG))
+        mock_get.assert_called_once()
+        url = mock_get.call_args[0][0]
+        self.assertEqual(url, 'https://acme.zendesk.com/api/v2/users/me.json')
 
-    def test_empty_string_returns_true(self):
-        self.assertTrue(_is_access_token_expiring({'access_token_expires_at': ''}))
+    @patch('tap_zendesk.oauth.requests.get')
+    def test_401_token_expired(self, mock_get):
+        """401 means token is expired — should return True."""
+        mock_get.return_value = MockResponse(401, text='Unauthorized')
+        self.assertTrue(_is_token_expired(self.BASE_CONFIG))
 
-    def test_invalid_date_string_returns_true(self):
-        self.assertTrue(_is_access_token_expiring({'access_token_expires_at': 'not-a-date'}))
+    @patch('tap_zendesk.oauth.requests.get')
+    def test_403_triggers_refresh(self, mock_get):
+        """403 (unexpected) should trigger refresh to be safe."""
+        mock_get.return_value = MockResponse(403, text='Forbidden')
+        self.assertTrue(_is_token_expired(self.BASE_CONFIG))
 
-    def test_numeric_value_returns_true(self):
-        self.assertTrue(_is_access_token_expiring({'access_token_expires_at': 12345}))
+    @patch('tap_zendesk.oauth.requests.get')
+    def test_500_triggers_refresh(self, mock_get):
+        """500 (unexpected) should trigger refresh to be safe."""
+        mock_get.return_value = MockResponse(500, text='Internal Server Error')
+        self.assertTrue(_is_token_expired(self.BASE_CONFIG))
 
-    def test_48_hours_in_future_returns_false(self):
-        future = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=48)
-        self.assertFalse(_is_access_token_expiring(
-            {'access_token_expires_at': future.isoformat()}))
+    @patch('tap_zendesk.oauth.requests.get')
+    def test_request_exception_triggers_refresh(self, mock_get):
+        """Network failure should trigger refresh."""
+        import requests as req
+        mock_get.side_effect = req.ConnectionError("Network unreachable")
+        self.assertTrue(_is_token_expired(self.BASE_CONFIG))
 
-    def test_24_hours_in_future_returns_false(self):
-        future = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=24)
-        self.assertFalse(_is_access_token_expiring(
-            {'access_token_expires_at': future.isoformat()}))
+    @patch('tap_zendesk.oauth.requests.get')
+    def test_correct_headers_sent(self, mock_get):
+        """Verify Authorization header is sent correctly."""
+        mock_get.return_value = MockResponse(200, {'user': {'id': 1}})
+        _is_token_expired(self.BASE_CONFIG)
+        headers = mock_get.call_args[1]['headers']
+        self.assertEqual(headers['Authorization'], 'Bearer some_at')
+        self.assertEqual(headers['Accept'], 'application/json')
 
-    def test_exactly_30_minutes_in_future_returns_true(self):
-        """At the 30-minute boundary — should trigger refresh."""
-        boundary = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=30)
-        self.assertTrue(_is_access_token_expiring(
-            {'access_token_expires_at': boundary.isoformat()}))
 
-    def test_1_minute_in_future_returns_true(self):
-        soon = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=1)
-        self.assertTrue(_is_access_token_expiring(
-            {'access_token_expires_at': soon.isoformat()}))
+# ===========================================================================
+# 5. refresh_credentials — END-TO-END FLOW
+# ===========================================================================
+class TestRefreshCredentialsE2E(unittest.TestCase):
+    """End-to-end tests for the main refresh_credentials function."""
 
-    def test_already_expired_returns_true(self):
-        past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
-        self.assertTrue(_is_access_token_expiring(
-            {'access_token_expires_at': past.isoformat()}))
+    BASE_CONFIG = {
+        'subdomain': 'acme',
+        'access_token': 'old_at',
+        'refresh_token': 'old_rt',
+        'client_id': 'cid',
+        'client_secret': 'cs',
+    }
+
+    @patch('tap_zendesk.oauth._write_config')
+    @patch('tap_zendesk.oauth._refresh_access_token')
+    @patch('tap_zendesk.oauth._is_token_expired', return_value=True)
+    def test_expired_token_triggers_refresh_and_write(self, mock_expired, mock_refresh, mock_write):
+        mock_refresh.return_value = {
+            'access_token': 'new_at',
+            'refresh_token': 'new_rt',
+        }
+        config = dict(self.BASE_CONFIG)
+        result = refresh_credentials(config, '/tmp/fake.json')
+
+        self.assertEqual(result['access_token'], 'new_at')
+        self.assertEqual(result['refresh_token'], 'new_rt')
+        mock_refresh.assert_called_once()
+        mock_write.assert_called_once_with('/tmp/fake.json', result)
+        # expires_at should NOT be set
+        self.assertNotIn('access_token_expires_at', result)
+
+    @patch('tap_zendesk.oauth._write_config')
+    @patch('tap_zendesk.oauth._refresh_access_token')
+    @patch('tap_zendesk.oauth._is_token_expired', return_value=False)
+    def test_valid_token_skips_refresh(self, mock_expired, mock_refresh, mock_write):
+        config = dict(self.BASE_CONFIG)
+        result = refresh_credentials(config, '/tmp/fake.json')
+
+        self.assertEqual(result['access_token'], 'old_at')
+        self.assertEqual(result['refresh_token'], 'old_rt')
+        mock_refresh.assert_not_called()
+        mock_write.assert_not_called()

--- a/test/unittests/test_oauth.py
+++ b/test/unittests/test_oauth.py
@@ -1,5 +1,4 @@
 import unittest
-import datetime
 from unittest.mock import patch
 
 from tap_zendesk.oauth import (
@@ -7,7 +6,7 @@ from tap_zendesk.oauth import (
     _refresh_access_token,
     ACCESS_TOKEN_EXPIRES_IN
 )
-
+from tap_zendesk.http import ZendeskError
 
 # ---------------------------------------------------------------------------
 # Helper: mock response object matching requests.Response interface
@@ -136,6 +135,6 @@ class TestRefreshAccessTokenAPI(unittest.TestCase):
     @patch('tap_zendesk.oauth.requests.post')
     def test_400_bad_request(self, mock_post):
         mock_post.return_value = MockResponse(400, text='{"error": "invalid_grant"}')
-        with self.assertRaises(Exception) as ctx:
+        with self.assertRaises(ZendeskError) as ctx:
             _refresh_access_token(self.BASE_CONFIG)
         self.assertIn('400', str(ctx.exception))

--- a/test/unittests/test_oauth.py
+++ b/test/unittests/test_oauth.py
@@ -1,10 +1,12 @@
+import datetime
 import unittest
 from unittest.mock import patch
 
 from tap_zendesk.oauth import (
     refresh_credentials,
     _refresh_access_token,
-    ACCESS_TOKEN_EXPIRES_IN
+    ACCESS_TOKEN_EXPIRES_IN,
+    _is_access_token_expiring
 )
 from tap_zendesk.http import ZendeskError
 
@@ -138,3 +140,50 @@ class TestRefreshAccessTokenAPI(unittest.TestCase):
         with self.assertRaises(ZendeskError) as ctx:
             _refresh_access_token(self.BASE_CONFIG)
         self.assertIn('400', str(ctx.exception))
+
+# ===========================================================================
+# 4. _is_access_token_expiring — DATE BOUNDARY CONDITIONS
+# ===========================================================================
+class TestIsAccessTokenExpiring(unittest.TestCase):
+    """All edge cases for expiry checking."""
+
+    def test_missing_key_returns_true(self):
+        self.assertTrue(_is_access_token_expiring({}))
+
+    def test_none_value_returns_true(self):
+        self.assertTrue(_is_access_token_expiring({'access_token_expires_at': None}))
+
+    def test_empty_string_returns_true(self):
+        self.assertTrue(_is_access_token_expiring({'access_token_expires_at': ''}))
+
+    def test_invalid_date_string_returns_true(self):
+        self.assertTrue(_is_access_token_expiring({'access_token_expires_at': 'not-a-date'}))
+
+    def test_numeric_value_returns_true(self):
+        self.assertTrue(_is_access_token_expiring({'access_token_expires_at': 12345}))
+
+    def test_48_hours_in_future_returns_false(self):
+        future = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=48)
+        self.assertFalse(_is_access_token_expiring(
+            {'access_token_expires_at': future.isoformat()}))
+
+    def test_24_hours_in_future_returns_false(self):
+        future = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=24)
+        self.assertFalse(_is_access_token_expiring(
+            {'access_token_expires_at': future.isoformat()}))
+
+    def test_exactly_30_minutes_in_future_returns_true(self):
+        """At the 30-minute boundary — should trigger refresh."""
+        boundary = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=30)
+        self.assertTrue(_is_access_token_expiring(
+            {'access_token_expires_at': boundary.isoformat()}))
+
+    def test_1_minute_in_future_returns_true(self):
+        soon = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=1)
+        self.assertTrue(_is_access_token_expiring(
+            {'access_token_expires_at': soon.isoformat()}))
+
+    def test_already_expired_returns_true(self):
+        past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
+        self.assertTrue(_is_access_token_expiring(
+            {'access_token_expires_at': past.isoformat()}))

--- a/test/unittests/test_oauth.py
+++ b/test/unittests/test_oauth.py
@@ -154,7 +154,7 @@ class TestIsTokenExpired(unittest.TestCase):
         """Token with plenty of remaining life should return False."""
         # expires_at=1_100_000, remaining=100_000 > buffer(10_800) → valid
         mock_get.return_value = MockResponse(200, {
-            'token': {'expires_at': 1_100_000}
+            'token': {'expires_at': '1970-01-13T17:33:20Z'}
         })
         self.assertFalse(_is_token_expired(self.BASE_CONFIG))
         mock_get.assert_called_once()
@@ -167,7 +167,7 @@ class TestIsTokenExpired(unittest.TestCase):
         """Token expiring within the 3-hour buffer should return True."""
         # expires_at=1_005_000, remaining=5_000 < buffer(10_800) → expired
         mock_get.return_value = MockResponse(200, {
-            'token': {'expires_at': 1_005_000}
+            'token': {'expires_at': '1970-01-12T15:10:00Z'}
         })
         self.assertTrue(_is_token_expired(self.BASE_CONFIG))
 
@@ -177,7 +177,7 @@ class TestIsTokenExpired(unittest.TestCase):
         """Token already past expiry time should return True."""
         # expires_at=950_000, remaining=-50_000 < buffer → expired
         mock_get.return_value = MockResponse(200, {
-            'token': {'expires_at': 950_000}
+            'token': {'expires_at': '1970-01-11T23:53:20Z'}
         })
         self.assertTrue(_is_token_expired(self.BASE_CONFIG))
 
@@ -211,7 +211,7 @@ class TestIsTokenExpired(unittest.TestCase):
     def test_correct_headers_sent(self, mock_get, mock_time):
         """Verify Authorization header is sent correctly."""
         mock_get.return_value = MockResponse(200, {
-            'token': {'expires_at': 1_100_000}
+            'token': {'expires_at': '1970-01-13T17:33:20Z'}
         })
         _is_token_expired(self.BASE_CONFIG)
         headers = mock_get.call_args[1]['headers']

--- a/test/unittests/test_oauth.py
+++ b/test/unittests/test_oauth.py
@@ -4,10 +4,8 @@ from unittest.mock import patch
 
 from tap_zendesk.oauth import (
     refresh_credentials,
-    _is_refresh_token_expiring,
     _refresh_access_token,
-    ACCESS_TOKEN_EXPIRES_IN,
-    REFRESH_TOKEN_EXPIRES_IN
+    ACCESS_TOKEN_EXPIRES_IN
 )
 
 
@@ -108,16 +106,13 @@ class TestRefreshAccessTokenAPI(unittest.TestCase):
             'access_token': 'fresh_at',
             'token_type': 'bearer',
             'refresh_token': 'fresh_rt',
-            'scope': 'read',
-            'expires_in': ACCESS_TOKEN_EXPIRES_IN,
-            'refresh_token_expires_in': REFRESH_TOKEN_EXPIRES_IN,
+            'expires_in': ACCESS_TOKEN_EXPIRES_IN
         }
         mock_post.return_value = MockResponse(200, token_resp)
         result = _refresh_access_token(self.BASE_CONFIG)
         self.assertEqual(result['access_token'], 'fresh_at')
         self.assertEqual(result['refresh_token'], 'fresh_rt')
         self.assertEqual(result['expires_in'], ACCESS_TOKEN_EXPIRES_IN)
-        self.assertEqual(result['refresh_token_expires_in'], REFRESH_TOKEN_EXPIRES_IN)
     
         url = mock_post.call_args[0][0]
         self.assertEqual(url, 'https://acme.zendesk.com/oauth/tokens')
@@ -126,7 +121,7 @@ class TestRefreshAccessTokenAPI(unittest.TestCase):
     @patch('tap_zendesk.oauth.requests.post')
     def test_200_correct_payload(self, mock_post):
         mock_post.return_value = MockResponse(200, {
-            'access_token': 'a', 'refresh_token': 'r', 'token_type': 'bearer', 'scope': 'read'
+            'access_token': 'a', 'refresh_token': 'r', 'token_type': 'bearer'
         })
         _refresh_access_token(self.BASE_CONFIG)
         payload = mock_post.call_args[1]['json']
@@ -134,9 +129,7 @@ class TestRefreshAccessTokenAPI(unittest.TestCase):
         self.assertEqual(payload['refresh_token'], 'old_rt')
         self.assertEqual(payload['client_id'], 'cid')
         self.assertEqual(payload['client_secret'], 'cs')
-        self.assertEqual(payload['scope'], 'read')
         self.assertEqual(payload['expires_in'], ACCESS_TOKEN_EXPIRES_IN)
-        self.assertEqual(payload['refresh_token_expires_in'], REFRESH_TOKEN_EXPIRES_IN)
 
 
     # --- 400 Bad Request ---
@@ -146,51 +139,3 @@ class TestRefreshAccessTokenAPI(unittest.TestCase):
         with self.assertRaises(Exception) as ctx:
             _refresh_access_token(self.BASE_CONFIG)
         self.assertIn('400', str(ctx.exception))
-
-# ===========================================================================
-# 4. _is_refresh_token_expiring — DATE BOUNDARY CONDITIONS
-# ===========================================================================
-class TestIsRefreshTokenExpiring(unittest.TestCase):
-    """All edge cases for expiry checking."""
-
-    def test_missing_key_returns_true(self):
-        self.assertTrue(_is_refresh_token_expiring({}))
-
-    def test_none_value_returns_true(self):
-        self.assertTrue(_is_refresh_token_expiring({'refresh_token_expires_at': None}))
-
-    def test_empty_string_returns_true(self):
-        self.assertTrue(_is_refresh_token_expiring({'refresh_token_expires_at': ''}))
-
-    def test_invalid_date_string_returns_true(self):
-        self.assertTrue(_is_refresh_token_expiring({'refresh_token_expires_at': 'not-a-date'}))
-
-    def test_numeric_value_returns_true(self):
-        self.assertTrue(_is_refresh_token_expiring({'refresh_token_expires_at': 12345}))
-
-    def test_90_days_in_future_returns_false(self):
-        future = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=90)
-        self.assertFalse(_is_refresh_token_expiring(
-            {'refresh_token_expires_at': future.isoformat()}))
-
-    def test_30_days_in_future_returns_false(self):
-        future = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=30)
-        self.assertFalse(_is_refresh_token_expiring(
-            {'refresh_token_expires_at': future.isoformat()}))
-
-    def test_exactly_1_day_in_future_returns_true(self):
-        """At the 1-day boundary — should trigger refresh."""
-        boundary = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
-        self.assertTrue(_is_refresh_token_expiring(
-            {'refresh_token_expires_at': boundary.isoformat()}))
-
-    def test_1_hour_in_future_returns_true(self):
-        soon = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1)
-        self.assertTrue(_is_refresh_token_expiring(
-            {'refresh_token_expires_at': soon.isoformat()}))
-
-    def test_already_expired_returns_true(self):
-        past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=1)
-        self.assertTrue(_is_refresh_token_expiring(
-            {'refresh_token_expires_at': past.isoformat()}))
-

--- a/test/unittests/test_oauth.py
+++ b/test/unittests/test_oauth.py
@@ -5,6 +5,7 @@ from tap_zendesk.oauth import (
     refresh_credentials,
     _refresh_access_token,
     _is_token_expired,
+    ACCESS_TOKEN_VALIDITY_SECONDS,
 )
 from tap_zendesk.http import ZendeskError
 
@@ -114,7 +115,7 @@ class TestRefreshAccessTokenAPI(unittest.TestCase):
         url = mock_post.call_args[0][0]
         self.assertEqual(url, 'https://acme.zendesk.com/oauth/tokens')
 
-    # --- 200 OK: verify request payload (no expires_in) ---
+    # --- 200 OK: verify request payload ---
     @patch('tap_zendesk.oauth.requests.post')
     def test_200_correct_payload(self, mock_post):
         mock_post.return_value = MockResponse(200, {
@@ -126,7 +127,7 @@ class TestRefreshAccessTokenAPI(unittest.TestCase):
         self.assertEqual(payload['refresh_token'], 'old_rt')
         self.assertEqual(payload['client_id'], 'cid')
         self.assertEqual(payload['client_secret'], 'cs')
-        self.assertNotIn('expires_in', payload)
+        self.assertEqual(payload['expires_in'], ACCESS_TOKEN_VALIDITY_SECONDS)
 
     # --- 400 Bad Request ---
     @patch('tap_zendesk.oauth.requests.post')
@@ -134,7 +135,7 @@ class TestRefreshAccessTokenAPI(unittest.TestCase):
         mock_post.return_value = MockResponse(400, text='{"error": "invalid_grant"}')
         with self.assertRaises(ZendeskError) as ctx:
             _refresh_access_token(self.BASE_CONFIG)
-        self.assertIn('400', str(ctx.exception))
+        self.assertIn('re-authorize', str(ctx.exception))
 
 
 # ===========================================================================
@@ -180,6 +181,14 @@ class TestIsTokenExpired(unittest.TestCase):
             'token': {'expires_at': '1970-01-11T23:53:20Z'}
         })
         self.assertTrue(_is_token_expired(self.BASE_CONFIG))
+
+    @patch('tap_zendesk.oauth.requests.get')
+    def test_token_no_expiration(self, mock_get):
+        """Token with null expires_at should return False (never expires)."""
+        mock_get.return_value = MockResponse(200, {
+            'token': {'expires_at': None}
+        })
+        self.assertFalse(_is_token_expired(self.BASE_CONFIG))
 
     @patch('tap_zendesk.oauth.requests.get')
     def test_401_token_expired(self, mock_get):

--- a/test/unittests/test_oauth.py
+++ b/test/unittests/test_oauth.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, MagicMock
 from tap_zendesk.oauth import (
     refresh_credentials,
     _refresh_access_token,
-    _is_token_expired,
+    is_token_valid,
     ACCESS_TOKEN_VALIDITY_SECONDS,
 )
 from tap_zendesk.http import ZendeskError
@@ -139,7 +139,7 @@ class TestRefreshAccessTokenAPI(unittest.TestCase):
 
 
 # ===========================================================================
-# 4. _is_token_expired — TOKEN INFO API CALL
+# 4. is_token_valid — TOKEN INFO API CALL
 # ===========================================================================
 class TestIsTokenExpired(unittest.TestCase):
     """Token expiry check via GET /api/v2/oauth/tokens/current.json."""
@@ -157,7 +157,7 @@ class TestIsTokenExpired(unittest.TestCase):
         mock_get.return_value = MockResponse(200, {
             'token': {'expires_at': '1970-01-13T17:33:20Z'}
         })
-        self.assertFalse(_is_token_expired(self.BASE_CONFIG))
+        self.assertTrue(is_token_valid(self.BASE_CONFIG))
         mock_get.assert_called_once()
         url = mock_get.call_args[0][0]
         self.assertEqual(url, 'https://acme.zendesk.com/api/v2/oauth/tokens/current.json')
@@ -170,7 +170,7 @@ class TestIsTokenExpired(unittest.TestCase):
         mock_get.return_value = MockResponse(200, {
             'token': {'expires_at': '1970-01-12T15:10:00Z'}
         })
-        self.assertTrue(_is_token_expired(self.BASE_CONFIG))
+        self.assertFalse(is_token_valid(self.BASE_CONFIG))
 
     @patch('tap_zendesk.oauth.time.time', return_value=1_000_000)
     @patch('tap_zendesk.oauth.requests.get')
@@ -180,7 +180,7 @@ class TestIsTokenExpired(unittest.TestCase):
         mock_get.return_value = MockResponse(200, {
             'token': {'expires_at': '1970-01-11T23:53:20Z'}
         })
-        self.assertTrue(_is_token_expired(self.BASE_CONFIG))
+        self.assertFalse(is_token_valid(self.BASE_CONFIG))
 
     @patch('tap_zendesk.oauth.requests.get')
     def test_token_no_expiration(self, mock_get):
@@ -188,32 +188,32 @@ class TestIsTokenExpired(unittest.TestCase):
         mock_get.return_value = MockResponse(200, {
             'token': {'expires_at': None}
         })
-        self.assertFalse(_is_token_expired(self.BASE_CONFIG))
+        self.assertTrue(is_token_valid(self.BASE_CONFIG))
 
     @patch('tap_zendesk.oauth.requests.get')
     def test_401_token_expired(self, mock_get):
         """401 means token is expired — should return True."""
         mock_get.return_value = MockResponse(401, text='Unauthorized')
-        self.assertTrue(_is_token_expired(self.BASE_CONFIG))
+        self.assertFalse(is_token_valid(self.BASE_CONFIG))
 
     @patch('tap_zendesk.oauth.requests.get')
     def test_403_triggers_refresh(self, mock_get):
         """403 (unexpected) should trigger refresh to be safe."""
         mock_get.return_value = MockResponse(403, text='Forbidden')
-        self.assertTrue(_is_token_expired(self.BASE_CONFIG))
+        self.assertFalse(is_token_valid(self.BASE_CONFIG))
 
     @patch('tap_zendesk.oauth.requests.get')
     def test_500_triggers_refresh(self, mock_get):
         """500 (unexpected) should trigger refresh to be safe."""
         mock_get.return_value = MockResponse(500, text='Internal Server Error')
-        self.assertTrue(_is_token_expired(self.BASE_CONFIG))
+        self.assertFalse(is_token_valid(self.BASE_CONFIG))
 
     @patch('tap_zendesk.oauth.requests.get')
     def test_request_exception_triggers_refresh(self, mock_get):
         """Network failure should trigger refresh."""
         import requests as req
         mock_get.side_effect = req.ConnectionError("Network unreachable")
-        self.assertTrue(_is_token_expired(self.BASE_CONFIG))
+        self.assertFalse(is_token_valid(self.BASE_CONFIG))
 
     @patch('tap_zendesk.oauth.time.time', return_value=1_000_000)
     @patch('tap_zendesk.oauth.requests.get')
@@ -222,7 +222,7 @@ class TestIsTokenExpired(unittest.TestCase):
         mock_get.return_value = MockResponse(200, {
             'token': {'expires_at': '1970-01-13T17:33:20Z'}
         })
-        _is_token_expired(self.BASE_CONFIG)
+        is_token_valid(self.BASE_CONFIG)
         headers = mock_get.call_args[1]['headers']
         self.assertEqual(headers['Authorization'], 'Bearer some_at')
         self.assertEqual(headers['Accept'], 'application/json')
@@ -244,7 +244,7 @@ class TestRefreshCredentialsE2E(unittest.TestCase):
 
     @patch('tap_zendesk.oauth._write_config')
     @patch('tap_zendesk.oauth._refresh_access_token')
-    @patch('tap_zendesk.oauth._is_token_expired', return_value=True)
+    @patch('tap_zendesk.oauth.is_token_valid', return_value=False)
     def test_expired_token_triggers_refresh_and_write(self, mock_expired, mock_refresh, mock_write):
         mock_refresh.return_value = {
             'access_token': 'new_at',
@@ -262,7 +262,7 @@ class TestRefreshCredentialsE2E(unittest.TestCase):
 
     @patch('tap_zendesk.oauth._write_config')
     @patch('tap_zendesk.oauth._refresh_access_token')
-    @patch('tap_zendesk.oauth._is_token_expired', return_value=False)
+    @patch('tap_zendesk.oauth.is_token_valid', return_value=True)
     def test_valid_token_skips_refresh(self, mock_expired, mock_refresh, mock_write):
         config = dict(self.BASE_CONFIG)
         result = refresh_credentials(config, '/tmp/fake.json')

--- a/test/unittests/test_oauth.py
+++ b/test/unittests/test_oauth.py
@@ -1,0 +1,196 @@
+import unittest
+import datetime
+from unittest.mock import patch
+
+from tap_zendesk.oauth import (
+    refresh_credentials,
+    _is_refresh_token_expiring,
+    _refresh_access_token,
+    ACCESS_TOKEN_EXPIRES_IN,
+    REFRESH_TOKEN_EXPIRES_IN
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: mock response object matching requests.Response interface
+# ---------------------------------------------------------------------------
+class MockResponse:
+    def __init__(self, status_code, json_data=None, text=''):
+        self.status_code = status_code
+        self._json = json_data
+        self.text = text
+
+    def json(self):
+        if self._json is None:
+            raise ValueError("No JSON")
+        return self._json
+
+
+# ===========================================================================
+# 1. BACKWARD COMPATIBILITY
+# ===========================================================================
+class TestBackwardCompatibility(unittest.TestCase):
+    """Config without refresh_token should pass through untouched."""
+
+    def test_no_refresh_token_access_token_only(self):
+        """Legacy OAuth: access_token present, no refresh_token."""
+        config = {
+            'subdomain': 'acme',
+            'access_token': 'legacy_at',
+            'start_date': '2024-01-01T00:00:00Z',
+        }
+        result = refresh_credentials(config, '/tmp/fake.json')
+        self.assertEqual(result['access_token'], 'legacy_at')
+        self.assertNotIn('refresh_token', result)
+
+    def test_api_token_email_auth(self):
+        """email+api_token auth has no access_token — should skip entirely."""
+        config = {
+            'subdomain': 'acme',
+            'email': 'agent@acme.com',
+            'api_token': 'zd_api_token_123',
+            'start_date': '2024-01-01T00:00:00Z',
+        }
+        result = refresh_credentials(config, '/tmp/fake.json')
+        self.assertEqual(result, config)
+        self.assertNotIn('access_token', result)
+        self.assertNotIn('refresh_token', result)
+
+    def test_empty_config_only_required_keys(self):
+        """Minimal config with only required keys."""
+        config = {
+            'subdomain': 'acme',
+            'start_date': '2024-01-01T00:00:00Z',
+        }
+        result = refresh_credentials(config, '/tmp/fake.json')
+        self.assertEqual(result, config)
+
+
+# ===========================================================================
+# 2. DEV MODE
+# ===========================================================================
+class TestDevMode(unittest.TestCase):
+    """--dev flag: reuse existing tokens, no API calls."""
+
+    @patch('tap_zendesk.oauth._write_config')
+    @patch('tap_zendesk.oauth.requests.post')
+    def test_dev_mode_returns_existing_tokens(self, mock_post, mock_write_config):
+        config = {
+            'subdomain': 'acme',
+            'access_token': 'dev_at',
+            'refresh_token': 'dev_rt',
+            'client_id': 'cid',
+            'client_secret': 'cs',
+        }
+        result = refresh_credentials(config, '/tmp/fake.json', dev_mode=True)
+        self.assertEqual(result['access_token'], 'dev_at')
+        self.assertEqual(result['refresh_token'], 'dev_rt')
+        mock_post.assert_not_called()
+        mock_write_config.assert_not_called()
+
+# ===========================================================================
+# 3. _refresh_access_token — API BEHAVIOUR SCENARIOS
+# ===========================================================================
+class TestRefreshAccessTokenAPI(unittest.TestCase):
+    """Test every HTTP response scenario from Zendesk /oauth/tokens."""
+
+    BASE_CONFIG = {
+        'subdomain': 'acme',
+        'refresh_token': 'old_rt',
+        'client_id': 'cid',
+        'client_secret': 'cs',
+    }
+
+    # --- 200 OK: normal success ---
+    @patch('tap_zendesk.oauth.requests.post')
+    def test_200_success_returns_token_data(self, mock_post):
+        token_resp = {
+            'access_token': 'fresh_at',
+            'token_type': 'bearer',
+            'refresh_token': 'fresh_rt',
+            'scope': 'read',
+            'expires_in': ACCESS_TOKEN_EXPIRES_IN,
+            'refresh_token_expires_in': REFRESH_TOKEN_EXPIRES_IN,
+        }
+        mock_post.return_value = MockResponse(200, token_resp)
+        result = _refresh_access_token(self.BASE_CONFIG)
+        self.assertEqual(result['access_token'], 'fresh_at')
+        self.assertEqual(result['refresh_token'], 'fresh_rt')
+        self.assertEqual(result['expires_in'], ACCESS_TOKEN_EXPIRES_IN)
+        self.assertEqual(result['refresh_token_expires_in'], REFRESH_TOKEN_EXPIRES_IN)
+    
+        url = mock_post.call_args[0][0]
+        self.assertEqual(url, 'https://acme.zendesk.com/oauth/tokens')
+
+    # --- 200 OK: verify request payload ---
+    @patch('tap_zendesk.oauth.requests.post')
+    def test_200_correct_payload(self, mock_post):
+        mock_post.return_value = MockResponse(200, {
+            'access_token': 'a', 'refresh_token': 'r', 'token_type': 'bearer', 'scope': 'read'
+        })
+        _refresh_access_token(self.BASE_CONFIG)
+        payload = mock_post.call_args[1]['json']
+        self.assertEqual(payload['grant_type'], 'refresh_token')
+        self.assertEqual(payload['refresh_token'], 'old_rt')
+        self.assertEqual(payload['client_id'], 'cid')
+        self.assertEqual(payload['client_secret'], 'cs')
+        self.assertEqual(payload['scope'], 'read')
+        self.assertEqual(payload['expires_in'], ACCESS_TOKEN_EXPIRES_IN)
+        self.assertEqual(payload['refresh_token_expires_in'], REFRESH_TOKEN_EXPIRES_IN)
+
+
+    # --- 400 Bad Request ---
+    @patch('tap_zendesk.oauth.requests.post')
+    def test_400_bad_request(self, mock_post):
+        mock_post.return_value = MockResponse(400, text='{"error": "invalid_grant"}')
+        with self.assertRaises(Exception) as ctx:
+            _refresh_access_token(self.BASE_CONFIG)
+        self.assertIn('400', str(ctx.exception))
+
+# ===========================================================================
+# 4. _is_refresh_token_expiring — DATE BOUNDARY CONDITIONS
+# ===========================================================================
+class TestIsRefreshTokenExpiring(unittest.TestCase):
+    """All edge cases for expiry checking."""
+
+    def test_missing_key_returns_true(self):
+        self.assertTrue(_is_refresh_token_expiring({}))
+
+    def test_none_value_returns_true(self):
+        self.assertTrue(_is_refresh_token_expiring({'refresh_token_expires_at': None}))
+
+    def test_empty_string_returns_true(self):
+        self.assertTrue(_is_refresh_token_expiring({'refresh_token_expires_at': ''}))
+
+    def test_invalid_date_string_returns_true(self):
+        self.assertTrue(_is_refresh_token_expiring({'refresh_token_expires_at': 'not-a-date'}))
+
+    def test_numeric_value_returns_true(self):
+        self.assertTrue(_is_refresh_token_expiring({'refresh_token_expires_at': 12345}))
+
+    def test_90_days_in_future_returns_false(self):
+        future = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=90)
+        self.assertFalse(_is_refresh_token_expiring(
+            {'refresh_token_expires_at': future.isoformat()}))
+
+    def test_30_days_in_future_returns_false(self):
+        future = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=30)
+        self.assertFalse(_is_refresh_token_expiring(
+            {'refresh_token_expires_at': future.isoformat()}))
+
+    def test_exactly_1_day_in_future_returns_true(self):
+        """At the 1-day boundary — should trigger refresh."""
+        boundary = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
+        self.assertTrue(_is_refresh_token_expiring(
+            {'refresh_token_expires_at': boundary.isoformat()}))
+
+    def test_1_hour_in_future_returns_true(self):
+        soon = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1)
+        self.assertTrue(_is_refresh_token_expiring(
+            {'refresh_token_expires_at': soon.isoformat()}))
+
+    def test_already_expired_returns_true(self):
+        past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=1)
+        self.assertTrue(_is_refresh_token_expiring(
+            {'refresh_token_expires_at': past.isoformat()}))
+

--- a/test/unittests/test_oauth.py
+++ b/test/unittests/test_oauth.py
@@ -138,24 +138,48 @@ class TestRefreshAccessTokenAPI(unittest.TestCase):
 
 
 # ===========================================================================
-# 4. _is_token_expired — CREDENTIAL CHECK API CALL
+# 4. _is_token_expired — TOKEN INFO API CALL
 # ===========================================================================
 class TestIsTokenExpired(unittest.TestCase):
-    """Credential check via GET /api/v2/users/me.json."""
+    """Token expiry check via GET /api/v2/oauth/tokens/current.json."""
 
     BASE_CONFIG = {
         'subdomain': 'acme',
         'access_token': 'some_at',
     }
 
+    @patch('tap_zendesk.oauth.time.time', return_value=1_000_000)
     @patch('tap_zendesk.oauth.requests.get')
-    def test_200_token_valid(self, mock_get):
-        """200 from /api/v2/users/me means token is valid."""
-        mock_get.return_value = MockResponse(200, {'user': {'id': 1}})
+    def test_token_valid_beyond_buffer(self, mock_get, mock_time):
+        """Token with plenty of remaining life should return False."""
+        # expires_at=1_100_000, remaining=100_000 > buffer(10_800) → valid
+        mock_get.return_value = MockResponse(200, {
+            'token': {'expires_at': 1_100_000}
+        })
         self.assertFalse(_is_token_expired(self.BASE_CONFIG))
         mock_get.assert_called_once()
         url = mock_get.call_args[0][0]
-        self.assertEqual(url, 'https://acme.zendesk.com/api/v2/users/me.json')
+        self.assertEqual(url, 'https://acme.zendesk.com/api/v2/oauth/tokens/current.json')
+
+    @patch('tap_zendesk.oauth.time.time', return_value=1_000_000)
+    @patch('tap_zendesk.oauth.requests.get')
+    def test_token_expiring_within_buffer(self, mock_get, mock_time):
+        """Token expiring within the 3-hour buffer should return True."""
+        # expires_at=1_005_000, remaining=5_000 < buffer(10_800) → expired
+        mock_get.return_value = MockResponse(200, {
+            'token': {'expires_at': 1_005_000}
+        })
+        self.assertTrue(_is_token_expired(self.BASE_CONFIG))
+
+    @patch('tap_zendesk.oauth.time.time', return_value=1_000_000)
+    @patch('tap_zendesk.oauth.requests.get')
+    def test_token_already_expired(self, mock_get, mock_time):
+        """Token already past expiry time should return True."""
+        # expires_at=950_000, remaining=-50_000 < buffer → expired
+        mock_get.return_value = MockResponse(200, {
+            'token': {'expires_at': 950_000}
+        })
+        self.assertTrue(_is_token_expired(self.BASE_CONFIG))
 
     @patch('tap_zendesk.oauth.requests.get')
     def test_401_token_expired(self, mock_get):
@@ -182,10 +206,13 @@ class TestIsTokenExpired(unittest.TestCase):
         mock_get.side_effect = req.ConnectionError("Network unreachable")
         self.assertTrue(_is_token_expired(self.BASE_CONFIG))
 
+    @patch('tap_zendesk.oauth.time.time', return_value=1_000_000)
     @patch('tap_zendesk.oauth.requests.get')
-    def test_correct_headers_sent(self, mock_get):
+    def test_correct_headers_sent(self, mock_get, mock_time):
         """Verify Authorization header is sent correctly."""
-        mock_get.return_value = MockResponse(200, {'user': {'id': 1}})
+        mock_get.return_value = MockResponse(200, {
+            'token': {'expires_at': 1_100_000}
+        })
         _is_token_expired(self.BASE_CONFIG)
         headers = mock_get.call_args[1]['headers']
         self.assertEqual(headers['Authorization'], 'Bearer some_at')


### PR DESCRIPTION
# Description of change
Introduce OAuth token expiry handling and a dev mode implementation.

**Authentication and OAuth Improvements:**

* Added `tap_zendesk/oauth.py` to handle OAuth token expiry and automatic refresh of `access_token` and `refresh_token`, persisting updated tokens back to config.
* Backward compatibility is preserved for legacy OAuth flows.
* Support the new `dev_mode` flag, which skips token refresh when enabled.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
