### PR TITLE
Fix connection failure for 403 Forbidden error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.7.3
+  * Fix connection failure when account lacks access to plan-restricted streams (`talk_phone_numbers`, `sla_policies`, `ticket_forms`, `satisfaction_ratings`) [#185](https://github.com/singer-io/tap-zendesk/pull/185)
+    * Added `is_optional` flag to `Stream` base class; optional streams excluded from catalog on 403 instead of blocking connection creation
+    * Fixed `TalkPhoneNumbers.check_access()` to handle `requests.exceptions.HTTPError` 403 and convert to `ZendeskForbiddenError`
+    * Fixed `SLAPolicies` and `TicketForms` `check_access()` to catch bare `APIException` and convert to `ZendeskForbiddenError`
+    * Hard-fail threshold now counts only essential streams (excludes optional streams)
+  * Fix `ValueError: Invalid format string` on Windows by replacing `strftime('%s')` with `.timestamp()` in `TicketMetricEvents`[#185](https://github.com/singer-io/tap-zendesk/pull/185)
+
 ## 2.7.2
   * Update aiohttp for twistlock [#178](https://github.com/singer-io/tap-zendesk/pull/178)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='2.7.2',
+      version='2.7.3',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',
@@ -23,7 +23,8 @@ setup(name='tap-zendesk',
           'test': [
               'pylint==3.0.3',
               'nose2',
-              'pytest'
+              'pytest',
+              'parameterized'
           ]
       },
       entry_points='''

--- a/tap_zendesk/discover.py
+++ b/tap_zendesk/discover.py
@@ -55,9 +55,9 @@ def discover_streams(client, config):
             # check if the error is of type dictionary and the message retrieved from the dictionary
             # is the expected message. If so, only then print the logger message and return the schema
             if isinstance(err, dict):
-                if err.get('message', None) == "You do not have access to this page. Please contact the account owner of this help desk for further help.":
+                if err.get('message', None) == "Access to this resource is restricted. Please contact the account administrator for assistance.":
                     error_list.append(stream.name)
-            elif args0.get('description') == "You are missing the following required scopes: read":
+            elif args0.get('description') == "Missing the following required scopes: read":
                 error_list.append(stream.name)
             else:
                 raise e from None # raise error if it is other than 403 forbidden error

--- a/tap_zendesk/discover.py
+++ b/tap_zendesk/discover.py
@@ -29,18 +29,25 @@ def discover_streams(client, config):
     error_list = []
     refs = load_shared_schema_refs()
 
-
     for stream in STREAMS.values():
         # for each stream in the `STREAMS` check if the user has the permission to access the data of that stream
         stream = stream(client, config)
         schema = singer.resolve_schema_references(stream.load_schema(), refs)
         try:
-            # Here it call the check_access method to check whether stream have read permission or not.
-            # If stream does not have read permission then append that stream name to list and at the end of all streams
-            # raise forbidden error with proper message containing stream names.
+            # Call check_access to verify the account has read permission for this stream.
             stream.check_access()
         except ZendeskForbiddenError:
-            error_list.append(stream.name) # Append stream name to the error_list
+            if stream.is_optional:
+                # This stream depends on a plan tier or paid add-on that is not available
+                # for this account (e.g. Talk, SLA Policies, Ticket Forms, Satisfaction Ratings).
+                # Per Option B: exclude it from the catalog so it does not appear in the
+                # stream selection list, rather than failing the connection.
+                LOGGER.warning(
+                    "Stream '%s' is not available for this account (plan tier or add-on not "
+                    "provisioned). It will be excluded from the available streams.", stream.name)
+                continue  # Do NOT append to streams list
+            # Essential stream: collect name; reported at the end of discovery.
+            error_list.append(stream.name)
         except zenpy.lib.exception.APIException as e:
             args0 = json.loads(e.args[0])
             err = args0.get('error')
@@ -58,20 +65,19 @@ def discover_streams(client, config):
         streams.append({'stream': stream.name, 'tap_stream_id': stream.name, 'schema': schema, 'metadata': stream.load_metadata()})
 
     if error_list:
-
-        total_stream = len(STREAMS.values()) # Total no of streams
+        # Use only essential (non-optional) streams as the threshold for the hard-fail check,
+        # since optional streams are excluded from the catalog rather than added to error_list.
+        total_essential_streams = sum(1 for s in STREAMS.values() if not s.is_optional)
         streams_name = ", ".join(error_list)
-        if len(error_list) != total_stream:
+        if len(error_list) != total_essential_streams:
             message = "The account credentials supplied do not have 'read' access to the following stream(s): {}. "\
                 "The data for these streams would not be collected due to lack of required permission.".format(streams_name)
-            # If atleast one stream have read permission then just print warning message for all streams
-            # which does not have read permission
+            # If at least one essential stream has read permission, warn about the others.
             LOGGER.warning(message)
         else:
-            message ="HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "\
-            "of streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
-            # If none of the streams are having the 'read' access, then the code will raise an error
+            message = "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "\
+                "of streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
+            # If none of the essential streams are accessible, fail the connection.
             raise ZendeskForbiddenError(message)
-
 
     return streams

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -4,6 +4,7 @@ import datetime
 import asyncio
 import time
 import pytz
+import requests
 from zenpy.lib.exception import APIException
 from aiohttp import ClientSession
 import singer
@@ -66,6 +67,10 @@ class Stream():
     endpoint = None
     request_timeout = None
     page_size = None
+    # Streams with is_optional=True depend on a specific plan tier or paid add-on.
+    # A 403 on these during discovery excludes them from the catalog rather than
+    # blocking connection creation.
+    is_optional = False
 
     def __init__(self, client=None, config=None):
         self.client = client
@@ -507,6 +512,7 @@ class TicketComments(Stream):
 class TalkPhoneNumbers(Stream):
     name = 'talk_phone_numbers'
     replication_method = "FULL_TABLE"
+    is_optional = True
 
     def sync(self, state): # pylint: disable=unused-argument
         for phone_number in self.client.talk.phone_numbers():
@@ -516,8 +522,28 @@ class TalkPhoneNumbers(Stream):
         try:
             self.client.talk.phone_numbers()
         except http.ZendeskNotFoundError:
-            #Skip 404 ZendeskNotFoundError error as goal is to just check to whether TicketComments have read permission or not
+            # Skip 404 as goal is to check whether TalkPhoneNumbers have read permission
             pass
+        except http.ZendeskForbiddenError:
+            raise  # Propagate to discover.py which adds stream to error_list
+        except requests.exceptions.HTTPError as e:
+            # Zenpy's Talk API raises requests.HTTPError directly for certain HTTP errors.
+            # Convert 403 Forbidden to ZendeskForbiddenError for consistent handling in discover.py.
+            if e.response is not None and e.response.status_code == 403:
+                raise http.ZendeskForbiddenError(str(e)) from None
+            raise
+        except APIException as e:
+            # Handle Zenpy APIException 403 with various message formats
+            try:
+                args0 = json.loads(e.args[0])
+                err = args0.get('error')
+                description = args0.get('description', '')
+            except (json.JSONDecodeError, ValueError, IndexError):
+                raise e
+            if (isinstance(err, dict) and err.get('message') == "You do not have access to this page. Please contact the account owner of this help desk for further help.") \
+                    or description == "You are missing the following required scopes: read":
+                raise http.ZendeskForbiddenError(str(e)) from None
+            raise
 
 class SatisfactionRatings(CursorBasedStream):
     name = "satisfaction_ratings"
@@ -525,6 +551,7 @@ class SatisfactionRatings(CursorBasedStream):
     replication_key = "updated_at"
     endpoint = 'https://{}.zendesk.com/api/v2/satisfaction_ratings'
     item_key = 'satisfaction_ratings'
+    is_optional = True
 
     def sync(self, state):
         bookmark = self.get_bookmark(state)
@@ -611,6 +638,7 @@ class TicketForms(Stream):
     name = "ticket_forms"
     replication_method = "INCREMENTAL"
     replication_key = "updated_at"
+    is_optional = True
 
     def sync(self, state):
         bookmark = self.get_bookmark(state)
@@ -628,7 +656,12 @@ class TicketForms(Stream):
         '''
         Check whether the permission was given to access stream resources or not.
         '''
-        self.client.ticket_forms()
+        try:
+            self.client.ticket_forms()
+        except APIException as e:
+            # ticket_forms is a plan-tier feature; re-raise any access denial as
+            # ZendeskForbiddenError so discover.py handles it consistently.
+            raise http.ZendeskForbiddenError(str(e)) from None
 
 class GroupMemberships(CursorBasedStream):
     name = "group_memberships"
@@ -662,6 +695,7 @@ class GroupMemberships(CursorBasedStream):
 class SLAPolicies(Stream):
     name = "sla_policies"
     replication_method = "FULL_TABLE"
+    is_optional = True
 
     def sync(self, state): # pylint: disable=unused-argument
         for policy in self.client.sla_policies():
@@ -671,7 +705,12 @@ class SLAPolicies(Stream):
         '''
         Check whether the permission was given to access stream resources or not.
         '''
-        self.client.sla_policies()
+        try:
+            self.client.sla_policies()
+        except APIException as e:
+            # sla_policies is a plan-tier feature; re-raise any access denial as
+            # ZendeskForbiddenError so discover.py handles it consistently.
+            raise http.ZendeskForbiddenError(str(e)) from None
 
 STREAMS = {
     "tickets": Tickets,

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -125,7 +125,6 @@ class Stream():
                 mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
             else:
                 mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'available')
-
         return metadata.to_list(mdata)
 
     def is_selected(self):
@@ -479,7 +478,7 @@ class TicketMetricEvents(Stream):
         bookmark = self.get_bookmark(state)
         start = bookmark - datetime.timedelta(seconds=1)
 
-        epoch_start = int(start.strftime('%s'))
+        epoch_start = int(start.timestamp())
         parsed_start = singer.strftime(start, "%Y-%m-%dT%H:%M:%SZ")
         ticket_metric_events = self.client.tickets.metrics_incremental(start_time=epoch_start)
         for event in ticket_metric_events:
@@ -491,7 +490,7 @@ class TicketMetricEvents(Stream):
 
     def check_access(self):
         try:
-            epoch_start = int(utils.now().strftime('%s'))
+            epoch_start = int(utils.now().timestamp())
             self.client.tickets.metrics_incremental(start_time=epoch_start)
         except http.ZendeskNotFoundError:
             #Skip 404 ZendeskNotFoundError error as goal is just to check whether TicketComments have read permission or not
@@ -657,9 +656,16 @@ class TicketForms(Stream):
         try:
             self.client.ticket_forms()
         except APIException as e:
-            # ticket_forms is a plan-tier feature; re-raise any access denial as
-            # ZendeskForbiddenError so discover.py handles it consistently.
-            raise http.ZendeskForbiddenError(str(e)) from None
+            try:
+                args0 = json.loads(e.args[0])
+                err = args0.get('error')
+                description = args0.get('description', '')
+            except (json.JSONDecodeError, ValueError, IndexError) as exc:
+                raise e from exc
+            if (isinstance(err, dict) and err.get('message') == "You do not have access to this page. Please contact the account owner of this help desk for further help.") \
+                    or description == "You are missing the following required scopes: read":
+                raise http.ZendeskForbiddenError(str(e)) from None
+            raise
 
 class GroupMemberships(CursorBasedStream):
     name = "group_memberships"
@@ -706,9 +712,16 @@ class SLAPolicies(Stream):
         try:
             self.client.sla_policies()
         except APIException as e:
-            # sla_policies is a plan-tier feature; re-raise any access denial as
-            # ZendeskForbiddenError so discover.py handles it consistently.
-            raise http.ZendeskForbiddenError(str(e)) from None
+            try:
+                args0 = json.loads(e.args[0])
+                err = args0.get('error')
+                description = args0.get('description', '')
+            except (json.JSONDecodeError, ValueError, IndexError) as exc:
+                raise e from exc
+            if (isinstance(err, dict) and err.get('message') == "You do not have access to this page. Please contact the account owner of this help desk for further help.") \
+                    or description == "You are missing the following required scopes: read":
+                raise http.ZendeskForbiddenError(str(e)) from None
+            raise
 
 STREAMS = {
     "tickets": Tickets,

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -524,8 +524,6 @@ class TalkPhoneNumbers(Stream):
         except http.ZendeskNotFoundError:
             # Skip 404 as goal is to check whether TalkPhoneNumbers have read permission
             pass
-        except http.ZendeskForbiddenError:
-            raise  # Propagate to discover.py which adds stream to error_list
         except requests.exceptions.HTTPError as e:
             # Zenpy's Talk API raises requests.HTTPError directly for certain HTTP errors.
             # Convert 403 Forbidden to ZendeskForbiddenError for consistent handling in discover.py.
@@ -538,8 +536,8 @@ class TalkPhoneNumbers(Stream):
                 args0 = json.loads(e.args[0])
                 err = args0.get('error')
                 description = args0.get('description', '')
-            except (json.JSONDecodeError, ValueError, IndexError):
-                raise e
+            except (json.JSONDecodeError, ValueError, IndexError) as exc:
+                raise e from exc
             if (isinstance(err, dict) and err.get('message') == "You do not have access to this page. Please contact the account owner of this help desk for further help.") \
                     or description == "You are missing the following required scopes: read":
                 raise http.ZendeskForbiddenError(str(e)) from None

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -175,14 +175,14 @@ def raise_or_log_zenpy_apiexception(schema, stream, e):
         raise ValueError("Called with a bad exception type") from e
 
     #If read permission is not available in OAuth access_token, then it returns the below error.
-    if json.loads(e.args[0]).get('description') == "You are missing the following required scopes: read":
+    if json.loads(e.args[0]).get('description') == "Missing the following required scopes: read":
         LOGGER.warning("The account credentials supplied do not have access to `%s` custom fields.",
                        stream)
         return schema
     error = json.loads(e.args[0]).get('error')
     # check if the error is of type dictionary and the message retrieved from the dictionary
     # is the expected message. If so, only then print the logger message and return the schema
-    if isinstance(error, dict) and error.get('message', None) == "You do not have access to this page. Please contact the account owner of this help desk for further help.":
+    if isinstance(error, dict) and error.get('message', None) == "Access to this resource is restricted. Please contact the account administrator for assistance.":
         LOGGER.warning("The account credentials supplied do not have access to `%s` custom fields.",
                        stream)
         return schema
@@ -537,8 +537,8 @@ class TalkPhoneNumbers(Stream):
                 description = args0.get('description', '')
             except (json.JSONDecodeError, ValueError, IndexError) as exc:
                 raise e from exc
-            if (isinstance(err, dict) and err.get('message') == "You do not have access to this page. Please contact the account owner of this help desk for further help.") \
-                    or description == "You are missing the following required scopes: read":
+            if (isinstance(err, dict) and err.get('message') == "Access to this resource is restricted. Please contact the account administrator for assistance.") \
+                    or description == "Missing the following required scopes: read":
                 raise http.ZendeskForbiddenError(str(e)) from None
             raise
 
@@ -662,8 +662,8 @@ class TicketForms(Stream):
                 description = args0.get('description', '')
             except (json.JSONDecodeError, ValueError, IndexError) as exc:
                 raise e from exc
-            if (isinstance(err, dict) and err.get('message') == "You do not have access to this page. Please contact the account owner of this help desk for further help.") \
-                    or description == "You are missing the following required scopes: read":
+            if (isinstance(err, dict) and err.get('message') == "Access to this resource is restricted. Please contact the account administrator for assistance.") \
+                    or description == "Missing the following required scopes: read":
                 raise http.ZendeskForbiddenError(str(e)) from None
             raise
 
@@ -718,8 +718,8 @@ class SLAPolicies(Stream):
                 description = args0.get('description', '')
             except (json.JSONDecodeError, ValueError, IndexError) as exc:
                 raise e from exc
-            if (isinstance(err, dict) and err.get('message') == "You do not have access to this page. Please contact the account owner of this help desk for further help.") \
-                    or description == "You are missing the following required scopes: read":
+            if (isinstance(err, dict) and err.get('message') == "Access to this resource is restricted. Please contact the account administrator for assistance.") \
+                    or description == "Missing the following required scopes: read":
                 raise http.ZendeskForbiddenError(str(e)) from None
             raise
 

--- a/test/test_all_streams.py
+++ b/test/test_all_streams.py
@@ -49,8 +49,8 @@ class ZendeskAllStreams(ZendeskTest):
         # Zenpy client credentials to connect to API
         creds = {
             'email': 'dev@stitchdata.com',
-            'password': os.getenv('TAP_ZENDESK_API_PASSWORD'),
             'subdomain': self.get_properties()['subdomain'],
+            'token': os.getenv('TAP_ZENDESK_API_TOKEN')
         }
 
         test_tags = ['test_tag_1', 'test_tag_2', 'test_tag_3']
@@ -79,7 +79,7 @@ class ZendeskAllStreams(ZendeskTest):
         # Zenpy client credentials to connect to API
         creds = {
             'email': 'dev@stitchdata.com',
-            'password': os.getenv('TAP_ZENDESK_API_PASSWORD'),
+            'token': os.getenv('TAP_ZENDESK_API_TOKEN'),
             'subdomain': self.get_properties()['subdomain'],
         }
 
@@ -173,7 +173,10 @@ class ZendeskAllStreams(ZendeskTest):
 
             if stream == 'tags':
                 # check to see if tags were already refreshed or not
-                if not self.tags_are_stale:
+                if self.tags_are_stale:
+                    # refresh has not been run yet, this means we already have some tags records
+                    self.refresh_tags(records)
+                else:
                     # tags were already refreshed so records were missing from first sync
                     messages = tags_records.get(stream).get('messages')
 

--- a/test/test_all_streams.py
+++ b/test/test_all_streams.py
@@ -165,7 +165,7 @@ class ZendeskAllStreams(ZendeskTest):
 
             # Ensure we replicated some tags records this time
             tags_records = runner.get_records_from_target_output()
-            self.assertGreater(len(tags_records, 0))
+            self.assertGreater(len(tags_records), 0)
 
 
         for stream in self.expected_sync_streams():

--- a/test/test_all_streams.py
+++ b/test/test_all_streams.py
@@ -173,10 +173,7 @@ class ZendeskAllStreams(ZendeskTest):
 
             if stream == 'tags':
                 # check to see if tags were already refreshed or not
-                if self.tags_are_stale:
-                    # refresh has not been run yet, this means we already have some tags records
-                    self.refresh_tags(records)
-                else:
+                if not self.tags_are_stale:
                     # tags were already refreshed so records were missing from first sync
                     messages = tags_records.get(stream).get('messages')
 

--- a/test/unittests/test_discovery_mode.py
+++ b/test/unittests/test_discovery_mode.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import MagicMock, Mock, patch
+from parameterized import parameterized
 from tap_zendesk import discover, http
+from tap_zendesk.streams import TalkPhoneNumbers, SLAPolicies, TicketForms
 import tap_zendesk
 import requests
 import zenpy
@@ -68,7 +70,7 @@ class TestDiscovery(unittest.TestCase):
         # Verifying the logger message
         mock_logger.assert_called_with("The account credentials supplied do not have 'read' access to the following stream(s): "\
             "groups, users, organizations, ticket_audits, ticket_fields, ticket_forms, group_memberships, macros, "\
-            "satisfaction_ratings, tags. The data for these streams would not be collected due to lack of required "\
+            "tags. The data for these streams would not be collected due to lack of required "\
             "permission.")
 
     @patch("tap_zendesk.discover.LOGGER.warning")
@@ -110,11 +112,11 @@ class TestDiscovery(unittest.TestCase):
         expected_call_count = 8
         actual_call_count = mock_get.call_count
         self.assertEqual(expected_call_count, actual_call_count)
-    
+
         # Verifying the logger message
         mock_logger.assert_called_with("The account credentials supplied do not have 'read' access to the following stream(s): "\
             "groups, users, organizations, ticket_audits, ticket_fields, ticket_forms, group_memberships, macros, "\
-            "satisfaction_ratings, tags, sla_policies. The data for these streams would not be collected due to "\
+            "tags, sla_policies. The data for these streams would not be collected due to "\
             "lack of required permission.")
 
     @patch("tap_zendesk.discover.LOGGER.warning")
@@ -158,7 +160,7 @@ class TestDiscovery(unittest.TestCase):
 
         # Verifying the logger message
         mock_logger.assert_called_with("The account credentials supplied do not have 'read' access to the following stream(s): "\
-            "tickets, groups, users, organizations, ticket_fields, ticket_forms, group_memberships, macros, satisfaction_ratings, "\
+            "tickets, groups, users, organizations, ticket_fields, ticket_forms, group_memberships, macros, "\
             "tags. The data for these streams would not be collected due to lack of required permission.")
         
     @patch('tap_zendesk.streams.TalkPhoneNumbers.check_access')
@@ -196,7 +198,7 @@ class TestDiscovery(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 400, Error: A validation exception has occurred."
             # Verifying the message formed for the custom exception
             self.assertEqual(str(e), expected_error_message)
-            
+
         expected_call_count = 4
         actual_call_count = mock_get.call_count
         self.assertEqual(expected_call_count, actual_call_count)
@@ -241,8 +243,7 @@ class TestDiscovery(unittest.TestCase):
         expected_call_count = 2
         actual_call_count = mock_get.call_count
         self.assertEqual(expected_call_count, actual_call_count)
-        
-        
+
     @patch('tap_zendesk.streams.TalkPhoneNumbers.check_access')
     @patch('tap_zendesk.streams.TicketMetricEvents.check_access')
     @patch('tap_zendesk.streams.Organizations.check_access',side_effect=[mocked_get(status_code=200, json={"key1": "val1"})])
@@ -319,3 +320,230 @@ class TestDiscovery(unittest.TestCase):
             "of streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
             # # Verifying the message formed for the custom exception
             self.assertEqual(str(e), expected_message)
+
+
+class TestOptionalStreamDiscovery(unittest.TestCase):
+    '''
+    Tests for the optional/essential stream distinction introduced to fix the customer-reported
+    issue: a 403 on a plan-tier or add-on stream (e.g. talk_phone_numbers, sla_policies,
+    ticket_forms, satisfaction_ratings) must NOT block connection creation.
+    '''
+
+    # -------------------------------------------------------------------------
+    # Test 1: Exact customer-reported scenario
+    #   OAuth client has no Zendesk Talk access → phone_numbers endpoint returns 403.
+    #   After our fix, TalkPhoneNumbers.check_access converts the HTTPError to
+    #   ZendeskForbiddenError. discover.py should exclude the stream silently and
+    #   continue – the connection must succeed.
+    # -------------------------------------------------------------------------
+    @patch('tap_zendesk.discover.LOGGER.warning')
+    @patch('tap_zendesk.streams.TalkPhoneNumbers.check_access',
+           side_effect=http.ZendeskForbiddenError(
+               '403 Client Error: Forbidden for url: '
+               'https://testaccount.zendesk.com/api/v2/channels/voice/phone_numbers.json'))
+    @patch('tap_zendesk.streams.SLAPolicies.check_access')         # succeeds
+    @patch('tap_zendesk.streams.TicketForms.check_access')          # succeeds
+    @patch('tap_zendesk.streams.TicketMetricEvents.check_access')   # succeeds
+    @patch('tap_zendesk.streams.Organizations.check_access')        # succeeds
+    @patch('tap_zendesk.streams.Users.check_access')                # succeeds
+    @patch('tap_zendesk.discover.load_shared_schema_refs', return_value={})
+    @patch('tap_zendesk.streams.Stream.load_metadata', return_value={})
+    @patch('tap_zendesk.streams.Stream.load_schema', return_value={})
+    @patch('singer.resolve_schema_references', return_value={})
+    @patch('requests.get', side_effect=[
+        mocked_get(status_code=200, json={'tickets': [{'id': 't1'}]}),  # tickets
+        mocked_get(status_code=200, json={'groups': []}),               # groups
+        mocked_get(status_code=200, json={}),                           # ticket_audits
+        mocked_get(status_code=200, json={}),                           # ticket_fields
+        mocked_get(status_code=200, json={}),                           # group_memberships
+        mocked_get(status_code=200, json={}),                           # macros
+        mocked_get(status_code=200, json={}),                           # satisfaction_ratings
+        mocked_get(status_code=200, json={}),                           # tags
+    ])
+    def test_talk_phone_numbers_403_excluded_connection_succeeds(
+            self, mock_get, mock_resolve_schema_references, mock_load_schema,
+            mock_load_metadata, mock_load_shared_schema_refs,
+            mock_users, mock_organizations, mock_ticket_metric_events,
+            mock_ticket_forms, mock_sla_policies, mock_talk_phone_numbers,
+            mock_logger):
+        '''
+        Replicates the exact customer-reported failure:
+          "Failed to create connection
+           403 Client Error: Forbidden for url: .../api/v2/channels/voice/phone_numbers.json"
+
+        The OAuth client has no Zendesk Talk product access. After the fix,
+        TalkPhoneNumbers.check_access raises ZendeskForbiddenError (converted from
+        requests.HTTPError). discover.py must:
+          1. NOT raise an exception (connection succeeds).
+          2. Exclude talk_phone_numbers from the returned catalog.
+          3. Log a warning identifying the excluded stream.
+        '''
+        result = discover.discover_streams(
+            'dummy_client',
+            {'subdomain': 'arp', 'access_token': 'dummy_token', 'start_date': START_DATE}
+        )
+
+        # Connection must succeed – 15 streams returned (all except talk_phone_numbers)
+        stream_names = [s['stream'] for s in result]
+        self.assertNotIn('talk_phone_numbers', stream_names)
+        self.assertEqual(len(result), 15)
+
+        # Warning must be logged for the excluded optional stream
+        mock_logger.assert_called_with(
+            "Stream '%s' is not available for this account (plan tier or add-on not "
+            "provisioned). It will be excluded from the available streams.",
+            'talk_phone_numbers'
+        )
+
+    # -------------------------------------------------------------------------
+    # Test 2: All four optional streams return 403
+    #   talk_phone_numbers (Talk add-on), sla_policies (plan-tier),
+    #   ticket_forms (plan-tier), satisfaction_ratings (plan-tier) all unavailable.
+    #   Connection must still succeed and all four must be absent from the catalog.
+    # -------------------------------------------------------------------------
+    @patch('tap_zendesk.discover.LOGGER.warning')
+    @patch('tap_zendesk.streams.TalkPhoneNumbers.check_access',
+           side_effect=http.ZendeskForbiddenError('403 Forbidden: talk not provisioned'))
+    @patch('tap_zendesk.streams.SLAPolicies.check_access',
+           side_effect=http.ZendeskForbiddenError('403 Forbidden: sla not on plan'))
+    @patch('tap_zendesk.streams.TicketForms.check_access',
+           side_effect=http.ZendeskForbiddenError('403 Forbidden: ticket_forms not on plan'))
+    @patch('tap_zendesk.streams.TicketMetricEvents.check_access')   # succeeds
+    @patch('tap_zendesk.streams.Organizations.check_access')        # succeeds
+    @patch('tap_zendesk.streams.Users.check_access')                # succeeds
+    @patch('tap_zendesk.discover.load_shared_schema_refs', return_value={})
+    @patch('tap_zendesk.streams.Stream.load_metadata', return_value={})
+    @patch('tap_zendesk.streams.Stream.load_schema', return_value={})
+    @patch('singer.resolve_schema_references', return_value={})
+    @patch('requests.get', side_effect=[
+        mocked_get(status_code=200, json={'tickets': [{'id': 't1'}]}),  # tickets
+        mocked_get(status_code=200, json={}),                           # groups
+        mocked_get(status_code=200, json={}),                           # ticket_audits
+        mocked_get(status_code=200, json={}),                           # ticket_fields
+        mocked_get(status_code=200, json={}),                           # group_memberships
+        mocked_get(status_code=200, json={}),                           # macros
+        mocked_get(status_code=403, json={}),                           # satisfaction_ratings (optional, 403 → excluded)
+        mocked_get(status_code=200, json={}),                           # tags
+    ])
+    def test_all_optional_streams_403_connection_still_succeeds(
+            self, mock_get, mock_resolve_schema_references, mock_load_schema,
+            mock_load_metadata, mock_load_shared_schema_refs,
+            mock_users, mock_organizations, mock_ticket_metric_events,
+            mock_ticket_forms, mock_sla_policies, mock_talk_phone_numbers,
+            mock_logger):
+        '''
+        When all four optional/plan-tier streams (talk_phone_numbers, sla_policies,
+        ticket_forms, satisfaction_ratings) return 403, the connection must still
+        succeed and all four must be excluded from the catalog. Essential streams
+        (tickets, groups, users, organizations, etc.) remain fully accessible.
+        '''
+        result = discover.discover_streams(
+            'dummy_client',
+            {'subdomain': 'arp', 'access_token': 'dummy_token', 'start_date': START_DATE}
+        )
+
+        # Connection succeeds: 12 essential streams remain (16 total − 4 optional excluded)
+        stream_names = [s['stream'] for s in result]
+        self.assertEqual(len(result), 12)
+
+        # All four optional streams must be absent
+        optional_streams = ['talk_phone_numbers', 'sla_policies', 'ticket_forms', 'satisfaction_ratings']
+        for stream in optional_streams:
+            self.assertNotIn(stream, stream_names)
+
+        # A warning must have been logged for each excluded optional stream
+        for stream in optional_streams:
+            mock_logger.assert_any_call(
+                "Stream '%s' is not available for this account (plan tier or add-on not "
+                "provisioned). It will be excluded from the available streams.",
+                stream
+            )
+
+
+class TestCheckAccessOptionalStreams(unittest.TestCase):
+    '''
+    Unit tests for the check_access() fixes on the three streams affected by the
+    customer-reported bug:
+      - TalkPhoneNumbers: Zenpy Talk raises requests.HTTPError directly (not ZendeskForbiddenError)
+      - SLAPolicies:      Zenpy native client raises APIException
+      - TicketForms:      Zenpy native client raises APIException
+    All three must convert their native exceptions to ZendeskForbiddenError so
+    discover.py can handle them uniformly via the is_optional flag.
+    '''
+
+    CONFIG = {
+        'subdomain': 'testaccount',
+        'access_token': 'test_token',
+        'start_date': START_DATE,
+    }
+
+    # -----------------------------------------------------------------------
+    # Parameterized: Zenpy native-client APIException → ZendeskForbiddenError
+    # Covers SLAPolicies and TicketForms which both use self.client.<method>()
+    # and must convert APIException to ZendeskForbiddenError.
+    # -----------------------------------------------------------------------
+    @parameterized.expand([
+        ('sla_policies',  SLAPolicies,  'sla_policies'),
+        ('ticket_forms',  TicketForms,  'ticket_forms'),
+    ])
+    def test_zenpy_api_exception_raises_zendesk_forbidden(self, _name, stream_cls, client_attr):
+        '''
+        Plan-tier streams (SLAPolicies, TicketForms) use the Zenpy native client.
+        A 403 surfaces as APIException; check_access() must re-raise it as
+        ZendeskForbiddenError for uniform handling in discover.py.
+        '''
+        client = MagicMock()
+        getattr(client, client_attr).side_effect = zenpy.lib.exception.APIException(ACCSESS_TOKEN_ERROR)
+        stream = stream_cls(client, self.CONFIG)
+
+        with self.assertRaises(http.ZendeskForbiddenError):
+            stream.check_access()
+
+    # -----------------------------------------------------------------------
+    # Parameterized: TalkPhoneNumbers check_access HTTP error handling
+    # The Zenpy Talk client calls response.raise_for_status() internally,
+    # so it surfaces errors as requests.HTTPError rather than ZendeskForbiddenError.
+    # -----------------------------------------------------------------------
+    @parameterized.expand([
+        (
+            'http_403_converted_to_zendesk_forbidden',
+            403,
+            '403 Client Error: Forbidden for url: '
+            'https://testaccount.zendesk.com/api/v2/channels/voice/phone_numbers.json',
+            http.ZendeskForbiddenError,
+        ),
+        (
+            'http_non_403_reraises_unchanged',
+            500,
+            '500 Server Error: Internal Server Error',
+            requests.exceptions.HTTPError,
+        ),
+    ])
+    def test_talk_phone_numbers_http_error(self, _name, status_code, error_msg, expected_exc):
+        '''
+        TalkPhoneNumbers.check_access() calls the Zenpy Talk client which raises
+        requests.HTTPError for HTTP errors:
+          - 403 must be converted to ZendeskForbiddenError (customer-reported scenario).
+          - Non-403 errors (e.g. 500) must propagate unchanged.
+        '''
+        client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = status_code
+        client.talk.phone_numbers.side_effect = requests.exceptions.HTTPError(
+            error_msg, response=mock_response
+        )
+        stream = TalkPhoneNumbers(client, self.CONFIG)
+
+        with self.assertRaises(expected_exc):
+            stream.check_access()
+
+    def test_talk_phone_numbers_404_silently_passes(self):
+        '''
+        ZendeskNotFoundError (404) should be silently ignored the account simply
+        has no phone numbers configured, which is not a permissions problem.
+        '''
+        client = MagicMock()
+        client.talk.phone_numbers.side_effect = http.ZendeskNotFoundError('Not Found')
+        stream = TalkPhoneNumbers(client, self.CONFIG)
+
+        stream.check_access()

--- a/test/unittests/test_discovery_mode.py
+++ b/test/unittests/test_discovery_mode.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import MagicMock, Mock, patch
 from parameterized import parameterized
 from tap_zendesk import discover, http
-from tap_zendesk.streams import TalkPhoneNumbers, SLAPolicies, TicketForms
+from tap_zendesk.streams import TalkPhoneNumbers, SLAPolicies, TicketForms, STREAMS
 import tap_zendesk
 import requests
 import zenpy
@@ -383,10 +383,12 @@ class TestOptionalStreamDiscovery(unittest.TestCase):
             {'subdomain': 'arp', 'access_token': 'dummy_token', 'start_date': START_DATE}
         )
 
-        # Connection must succeed – 15 streams returned (all except talk_phone_numbers)
+        # Connection must succeed – all streams except talk_phone_numbers are returned.
+        # Derive the expected count from STREAMS so this test isn't broken by unrelated stream additions.
+        excluded_streams = {'talk_phone_numbers'}
         stream_names = [s['stream'] for s in result]
         self.assertNotIn('talk_phone_numbers', stream_names)
-        self.assertEqual(len(result), 15)
+        self.assertEqual(len(result), len(STREAMS) - len(excluded_streams))
 
         # Warning must be logged for the excluded optional stream
         mock_logger.assert_called_with(
@@ -442,12 +444,13 @@ class TestOptionalStreamDiscovery(unittest.TestCase):
             {'subdomain': 'arp', 'access_token': 'dummy_token', 'start_date': START_DATE}
         )
 
-        # Connection succeeds: 12 essential streams remain (16 total − 4 optional excluded)
+        # Connection succeeds: all optional streams excluded, essential streams remain.
+        # Derive the expected count from STREAMS so this test isn't broken by unrelated stream additions.
+        optional_streams = {'talk_phone_numbers', 'sla_policies', 'ticket_forms', 'satisfaction_ratings'}
         stream_names = [s['stream'] for s in result]
-        self.assertEqual(len(result), 12)
+        self.assertEqual(len(result), len(STREAMS) - len(optional_streams))
 
         # All four optional streams must be absent
-        optional_streams = ['talk_phone_numbers', 'sla_policies', 'ticket_forms', 'satisfaction_ratings']
         for stream in optional_streams:
             self.assertNotIn(stream, stream_names)
 
@@ -539,7 +542,7 @@ class TestCheckAccessOptionalStreams(unittest.TestCase):
 
     def test_talk_phone_numbers_404_silently_passes(self):
         '''
-        ZendeskNotFoundError (404) should be silently ignored the account simply
+        ZendeskNotFoundError (404) should be silently ignored if the account simply
         has no phone numbers configured, which is not a permissions problem.
         '''
         client = MagicMock()

--- a/test/unittests/test_discovery_mode.py
+++ b/test/unittests/test_discovery_mode.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import MagicMock, Mock, patch
 from parameterized import parameterized
 from tap_zendesk import discover, http
-from tap_zendesk.streams import TalkPhoneNumbers, SLAPolicies, TicketForms, STREAMS
+from tap_zendesk.streams import TalkPhoneNumbers, SLAPolicies, TicketForms, SatisfactionRatings, STREAMS
 import tap_zendesk
 import requests
 import zenpy
@@ -162,7 +162,7 @@ class TestDiscovery(unittest.TestCase):
         mock_logger.assert_called_with("The account credentials supplied do not have 'read' access to the following stream(s): "\
             "tickets, groups, users, organizations, ticket_fields, ticket_forms, group_memberships, macros, "\
             "tags. The data for these streams would not be collected due to lack of required permission.")
-        
+
     @patch('tap_zendesk.streams.TalkPhoneNumbers.check_access')
     @patch('tap_zendesk.streams.TicketMetricEvents.check_access')
     @patch('tap_zendesk.streams.Organizations.check_access',side_effect=zenpy.lib.exception.APIException(ACCSESS_TOKEN_ERROR))
@@ -391,7 +391,7 @@ class TestOptionalStreamDiscovery(unittest.TestCase):
         self.assertEqual(len(result), len(STREAMS) - len(excluded_streams))
 
         # Warning must be logged for the excluded optional stream
-        mock_logger.assert_called_with(
+        mock_logger.assert_any_call(
             "Stream '%s' is not available for this account (plan tier or add-on not "
             "provisioned). It will be excluded from the available streams.",
             'talk_phone_numbers'
@@ -550,3 +550,34 @@ class TestCheckAccessOptionalStreams(unittest.TestCase):
         stream = TalkPhoneNumbers(client, self.CONFIG)
 
         stream.check_access()
+
+    # -----------------------------------------------------------------------
+    # SatisfactionRatings: base class check_access() via http.call_api
+    # Confirms the implicit contract: http.call_api → raise_for_error maps
+    # HTTP 403 to ZendeskForbiddenError, so no dedicated override is needed.
+    # -----------------------------------------------------------------------
+    def test_satisfaction_ratings_403_raises_zendesk_forbidden(self):
+        '''
+        SatisfactionRatings.is_optional=True relies on the base Stream.check_access()
+        which calls http.call_api(). raise_for_error() maps HTTP 403 directly to
+        ZendeskForbiddenError via ERROR_CODE_EXCEPTION_MAPPING — no override is
+        needed. This test explicitly guards that contract so the implicit dependency
+        on http.call_api behaviour is visible and regression-protected.
+        '''
+        with patch('requests.get', return_value=mocked_get(
+                status_code=403, json={'error': 'Forbidden'})):
+            stream = SatisfactionRatings(MagicMock(), self.CONFIG)
+            with self.assertRaises(http.ZendeskForbiddenError):
+                stream.check_access()
+
+    def test_satisfaction_ratings_non_403_reraises_unchanged(self):
+        '''
+        A non-403 error raised by http.call_api must propagate unchanged.
+        We patch http.call_api directly to avoid triggering the backoff decorator
+        (which retries 5xx errors up to 10 times, causing the test to hang).
+        '''
+        with patch('tap_zendesk.streams.http.call_api',
+                   side_effect=http.ZendeskInternalServerError('500 Server Error')):
+            stream = SatisfactionRatings(MagicMock(), self.CONFIG)
+            with self.assertRaises(http.ZendeskInternalServerError):
+                stream.check_access()

--- a/test/unittests/test_discovery_mode.py
+++ b/test/unittests/test_discovery_mode.py
@@ -7,9 +7,9 @@ import tap_zendesk
 import requests
 import zenpy
 
-ACCSESS_TOKEN_ERROR = '{"error": "Forbidden", "description": "You are missing the following required scopes: read"}'
+ACCSESS_TOKEN_ERROR = '{"error": "Forbidden", "description": "Missing the following required scopes: read"}'
 API_TOKEN_ERROR = '{"error": {"title": "Forbidden",'\
-        '"message": "You do not have access to this page. Please contact the account owner of this help desk for further help."}}'
+        '"message": "Access to this resource is restricted. Please contact the account administrator for assistance."}}'
 AUTH_ERROR = '{"error": "Could not authenticate you"}'
 START_DATE = "2021-10-30T00:00:00Z"
 

--- a/test/unittests/test_exception.py
+++ b/test/unittests/test_exception.py
@@ -20,13 +20,13 @@ class TestException(unittest.TestCase):
         """
         schema = {}
         stream = 'test_stream'
-        error_string = '{"error":{"message": "You do not have access to this page. Please contact the account owner of this help desk for further help."}' + "}"
+        error_string = '{"error":{"message": "Access to this resource is restricted. Please contact the account administrator for assistance."}}'
         e = APIException(error_string)
         raise_or_log_zenpy_apiexception(schema, stream, e)
         mocked_logger.assert_called_with(
             "The account credentials supplied do not have access to `%s` custom fields.",
             stream)
-        
+
     def test_zenpy_exception_raised(self):
         """
         Test whether the no logger message is printed in case of errors other then access error and the exception is raised
@@ -40,7 +40,7 @@ class TestException(unittest.TestCase):
         except APIException as ex:
             self.assertEqual(str(ex), error_string)
 
-        
+
     def test_zenpy_exception_but_different_message_raised(self):
         """
         Test whether the exception is raised when the error is a dict but with different error message

--- a/test/unittests/test_http.py
+++ b/test/unittests/test_http.py
@@ -383,7 +383,7 @@ class TestBackoff(unittest.TestCase):
     def test_raise_or_log_zenpy_apiexception(self, mocked_logger, mock_sleep):
         schema = {}
         stream = "test_stream"
-        error_string = '{"error": "Forbidden", "description": "You are missing the following required scopes: read"}'
+        error_string = '{"error": "Forbidden", "description": "Missing the following required scopes: read"}'
         e = zenpy.lib.exception.APIException(error_string)
         streams.raise_or_log_zenpy_apiexception(schema, stream, e)
         # Verify the raise_or_log_zenpy_apiexception Log expected message


### PR DESCRIPTION
# Description of change
PR included fix for connection error, connection creation was failing with a hard error when the account did not have access to certain Zendesk endpoints (e.g. Talk, SLA Policies, Ticket Forms). During discovery, check_access() raised unhandled exceptions that crashed the entire connection instead of gracefully skipping unavailable streams.
[SAC-30519](https://qlik-dev.atlassian.net/browse/SAC-30519)

# Manual QA steps
- [x]  Discovery: Running
- [x]  Sync: Running
- [x]  Unit Tests: Running
- [x]  Integration test: Running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
