### PR TITLE
bump aiohttp to 3.13.4 for security updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
+# 2.8.2
+  * Bump aiohttp to 3.13.4 for security updates [#186](https://github.com/singer-io/tap-zendesk/pull/186)
+
 # 2.8.1
   * Bump requests to 2.33.0 for security updates [#185](https://github.com/singer-io/tap-zendesk/pull/185)
-
 
 ## 2.8.0
   * Handle Oauth token expiry [#182](https://github.com/singer-io/tap-zendesk/pull/182)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='2.8.1',
+      version='2.8.2',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',
@@ -14,7 +14,7 @@ setup(name='tap-zendesk',
           'zenpy==2.0.24',
           'backoff==2.2.1',
           'requests==2.33.0',
-          'aiohttp==3.13.3'
+          'aiohttp==3.13.4'
       ],
       extras_require={
           'dev': [


### PR DESCRIPTION
# Description of change
bump `aiohttp==3.13.4` for security updates

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
