### PR TITLE
SAC-31707: mark ticket child streams with parent-tap-stream-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 2.8.3
+  * Bump aiohttp to 3.14.1 for security updates
+  * Mark `ticket_audits`, `ticket_comments`, and `ticket_metrics` as child streams of `tickets`
+  * [#190](https://github.com/singer-io/tap-zendesk/pull/190)
+
 # 2.8.2
   * Bump aiohttp to 3.13.4 for security updates [#186](https://github.com/singer-io/tap-zendesk/pull/186)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='2.8.2',
+      version='2.8.3',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',
@@ -14,7 +14,7 @@ setup(name='tap-zendesk',
           'zenpy==2.0.24',
           'backoff==2.2.1',
           'requests==2.33.0',
-          'aiohttp==3.13.4'
+          'aiohttp==3.14.1'
       ],
       extras_require={
           'dev': [

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -67,6 +67,9 @@ class Stream():
     endpoint = None
     request_timeout = None
     page_size = None
+    # Streams synced as sub-streams of another stream set `parent` to the
+    # parent's tap_stream_id so the catalog denotes the parent-child relationship.
+    parent = None
     # Streams with is_optional=True depend on a specific plan tier or paid add-on.
     # A 403 on these during discovery excludes them from the catalog rather than
     # blocking connection creation.
@@ -116,6 +119,9 @@ class Stream():
 
         mdata = metadata.write(mdata, (), 'table-key-properties', self.key_properties)
         mdata = metadata.write(mdata, (), 'forced-replication-method', self.replication_method)
+
+        if self.parent:
+            mdata = metadata.write(mdata, (), 'parent-tap-stream-id', self.parent)
 
         if self.replication_key:
             mdata = metadata.write(mdata, (), 'valid-replication-keys', [self.replication_key])
@@ -385,6 +391,7 @@ class Tickets(CursorBasedExportStream):
 class TicketAudits(Stream):
     name = "ticket_audits"
     replication_method = "INCREMENTAL"
+    parent = "tickets"
     count = 0
     endpoint='https://{}.zendesk.com/api/v2/tickets/{}/audits.json'
     item_key='audits'
@@ -459,6 +466,7 @@ class TicketAudits(Stream):
 class TicketMetrics(CursorBasedStream):
     name = "ticket_metrics"
     replication_method = "INCREMENTAL"
+    parent = "tickets"
     count = 0
 
     def check_access(self):
@@ -499,6 +507,7 @@ class TicketMetricEvents(Stream):
 class TicketComments(Stream):
     name = "ticket_comments"
     replication_method = "INCREMENTAL"
+    parent = "tickets"
     count = 0
 
     def check_access(self):

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -67,8 +67,6 @@ class Stream():
     endpoint = None
     request_timeout = None
     page_size = None
-    # Streams synced as sub-streams of another stream set `parent` to the
-    # parent's tap_stream_id so the catalog denotes the parent-child relationship.
     parent = None
     # Streams with is_optional=True depend on a specific plan tier or paid add-on.
     # A 403 on these during discovery excludes them from the catalog rather than


### PR DESCRIPTION
# Description of change
https://qlik-dev.atlassian.net/browse/SAC-31707

The tap already treats `ticket_comments`, `ticket_audits`, and `ticket_metrics` as child streams of `tickets` and requires that they only be synced with their parent [here](https://github.com/singer-io/tap-zendesk/blob/03eedfd9446a72a93053af151eecab9774bc2d3e/tap_zendesk/__init__.py#L100-L111). But the missing `parent-tap-stream-id` metadata is causing the streams to be grouped incorrectly.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
