### PR TITLE
SAC-31696: refresh OAuth token before a sync can outlive it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 2.8.4
+  * Refresh the OAuth access token whenever it could expire before the sync ends, rather than only within 3 hours of expiry
+
 # 2.8.3
   * Bump aiohttp to 3.14.1 for security updates
   * Mark `ticket_audits`, `ticket_comments`, and `ticket_metrics` as child streams of `tickets`

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='2.8.3',
+      version='2.8.4',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',

--- a/tap_zendesk/oauth.py
+++ b/tap_zendesk/oauth.py
@@ -31,8 +31,10 @@ TOKEN_REFRESH_URL = "https://{subdomain}.zendesk.com/oauth/tokens"
 # Endpoint to inspect the current OAuth token
 TOKEN_INFO_URL = "https://{subdomain}.zendesk.com/api/v2/oauth/tokens/current.json"
 
-# Refresh the token if it expires within this many seconds (3 hours)
-EXPIRY_BUFFER_SECONDS = 3 * 60 * 60
+# The token is only checked once, at startup, while a sync can run for just under a
+# day. A window narrower than that lets a token pass this check and still expire
+# mid-sync, which surfaces as an unrecoverable 401 partway through a load.
+EXPIRY_BUFFER_SECONDS = 25 * 60 * 60
 
 ACCESS_TOKEN_VALIDITY_SECONDS = 48 * 60 * 60
 

--- a/test/unittests/test_oauth.py
+++ b/test/unittests/test_oauth.py
@@ -6,6 +6,7 @@ from tap_zendesk.oauth import (
     _refresh_access_token,
     is_token_valid,
     ACCESS_TOKEN_VALIDITY_SECONDS,
+    EXPIRY_BUFFER_SECONDS,
 )
 from tap_zendesk.http import ZendeskError
 
@@ -153,7 +154,7 @@ class TestIsTokenExpired(unittest.TestCase):
     @patch('tap_zendesk.oauth.requests.get')
     def test_token_valid_beyond_buffer(self, mock_get, mock_time):
         """Token with plenty of remaining life should return False."""
-        # expires_at=1_100_000, remaining=100_000 > buffer(10_800) → valid
+        # expires_at=1_100_000, remaining=100_000 > buffer(90_000) → valid
         mock_get.return_value = MockResponse(200, {
             'token': {'expires_at': '1970-01-13T17:33:20Z'}
         })
@@ -165,8 +166,8 @@ class TestIsTokenExpired(unittest.TestCase):
     @patch('tap_zendesk.oauth.time.time', return_value=1_000_000)
     @patch('tap_zendesk.oauth.requests.get')
     def test_token_expiring_within_buffer(self, mock_get, mock_time):
-        """Token expiring within the 3-hour buffer should return True."""
-        # expires_at=1_005_000, remaining=5_000 < buffer(10_800) → expired
+        """Token expiring within the buffer should return True."""
+        # expires_at=1_005_000, remaining=5_000 < buffer(90_000) → expired
         mock_get.return_value = MockResponse(200, {
             'token': {'expires_at': '1970-01-12T15:10:00Z'}
         })
@@ -181,6 +182,26 @@ class TestIsTokenExpired(unittest.TestCase):
             'token': {'expires_at': '1970-01-11T23:53:20Z'}
         })
         self.assertFalse(is_token_valid(self.BASE_CONFIG))
+
+    @patch('tap_zendesk.oauth.time.time', return_value=1_000_000)
+    @patch('tap_zendesk.oauth.requests.get')
+    def test_token_outlived_by_a_long_sync_is_refreshed(self, mock_get, mock_time):
+        """A token good for 20h must still be refreshed: the sync can outlive it.
+
+        The token is only checked here, at startup, so anything not refreshed now has
+        to survive the whole run.
+        """
+        # expires_at=1_072_000, remaining=72_000 (20h) < buffer(90_000) → refresh
+        mock_get.return_value = MockResponse(200, {
+            'token': {'expires_at': '1970-01-13T09:46:40Z'}
+        })
+        self.assertFalse(is_token_valid(self.BASE_CONFIG))
+
+    def test_buffer_clears_the_longest_possible_sync(self):
+        """Guards the invariant the buffer exists for; a smaller value reintroduces
+        mid-sync 401s. Orchestrator deadline for a sync job is just under 24h."""
+        longest_sync_seconds = 24 * 60 * 60
+        self.assertGreater(EXPIRY_BUFFER_SECONDS, longest_sync_seconds)
 
     @patch('tap_zendesk.oauth.requests.get')
     def test_token_no_expiration(self, mock_get):


### PR DESCRIPTION
# Description of change

[SAC-31696: \[QTC Prod\]\[tap-zendesk\] 401 API error - Invalid Token](https://qlik-dev.atlassian.net/browse/SAC-31696)

### TL;DR

The tap checks its OAuth token once, at startup, and only refreshes it if it expires within three hours. A sync can run for nearly a day, so a token can pass that check and still die partway through the load.

___

`refresh_credentials` runs once, before discovery or sync, and `is_token_valid` returns True whenever the token has more than `EXPIRY_BUFFER_SECONDS` left. That buffer is three hours, while a sync job runs until its orchestrator deadline of just under 24 hours. A token with, say, twenty hours remaining is therefore left alone and expires mid-sync.

That 401 is unrecoverable rather than merely inconvenient:
- `is_fatal` classifies any non-429/409 4xx as fatal, so backoff gives up after one try
- the access token is captured into a headers dict once per generator (`get_incremental_export` and the three sibling paginators), so nothing re-reads the credential even if it were rotated
- `ZendeskUnauthorizedError` is never caught anywhere in the package

Widening the window past the longest possible sync means any token not refreshed at startup is guaranteed to outlive the run, which removes the failure mode without adding a mid-request refresh path.

Deliberately not done here: per-request header construction and reactive 401-refresh-retry. Both are genuine latent issues, but with this window no token can expire mid-run, so they would add a rotation path that can fail without fixing anything today. Better as their own change.

# Manual QA steps
 - Authorise a connection whose OAuth client issues expiring access tokens, wait past the token TTL, then run an extraction. It should refresh at startup and complete, where previously discovery failed with `HTTP-error-code: 401, Error: invalid_token`.
 - Confirm the tap logs `Successfully refreshed access_token and refresh_token` rather than passing silently through `refresh_credentials`.

Automated: `122 passed`. Two new tests, both confirmed red against unmodified `master` and green after:
- `test_token_outlived_by_a_long_sync_is_refreshed` - a token with 20h remaining must now refresh
- `test_buffer_clears_the_longest_possible_sync` - pins the invariant so the window cannot be narrowed back below a full-length sync

`pylint` output identical to `master`, same 9.54/10.

# Risks
 - More frequent refreshes. With a 48h token and this window, rotation happens roughly daily instead of never. Zendesk deletes the previous token pair on each refresh, so the platform must persist the rotated pair; that side is handled separately.
 - Where the token has a short TTL, every run now refreshes at startup. That is correct behaviour, but it does make the platform's persistence path load-bearing.

# Rollback steps
 - revert this branch