### PR TITLE
Update schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 2.8.6
+  * Schema updates [#199](https://github.com/singer-io/tap-zendesk/pull/199)
+
 # 2.8.5
   * Bump aiohttp from 3.14.1 -> 3.14.3 [#192](https://github.com/singer-io/tap-zendesk/pull/192)
 

--- a/setup.py
+++ b/setup.py
@@ -3,17 +3,17 @@
 from setuptools import setup
 
 setup(name='tap-zendesk',
-      version='2.8.5',
+      version='2.8.6',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Stitch',
       url='https://singer.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_zendesk'],
       install_requires=[
-          'singer-python==6.0.1',
-          'zenpy==2.0.24',
+          'singer-python==6.8.0',
+          'zenpy==2.0.57',
           'backoff==2.2.1',
-          'requests==2.33.0',
+          'requests==2.34.2',
           'aiohttp==3.14.3'
       ],
       extras_require={

--- a/tap_zendesk/schemas/groups.json
+++ b/tap_zendesk/schemas/groups.json
@@ -4,6 +4,24 @@
     "object"
   ],
   "properties": {
+    "default": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "description": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "is_public": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
     "name": {
       "type": [
         "null",

--- a/tap_zendesk/schemas/ticket_fields.json
+++ b/tap_zendesk/schemas/ticket_fields.json
@@ -1,5 +1,23 @@
 {
   "properties": {
+    "agent_can_edit": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "key": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "raw_agent_description": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "created_at": {
       "type": [
         "null",

--- a/tap_zendesk/schemas/ticket_forms.json
+++ b/tap_zendesk/schemas/ticket_forms.json
@@ -1,5 +1,32 @@
 {
   "properties": {
+    "agent_conditions": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {}
+    },
+    "end_user_conditions": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {}
+    },
+    "deleted_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "form_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "created_at": {
       "type": [
         "null",

--- a/tap_zendesk/schemas/ticket_metrics.json
+++ b/tap_zendesk/schemas/ticket_metrics.json
@@ -1,5 +1,12 @@
 {
   "properties": {
+    "custom_status_updated_at": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
     "metric": {
       "type": [
         "null",

--- a/tap_zendesk/schemas/tickets.json
+++ b/tap_zendesk/schemas/tickets.json
@@ -1,5 +1,36 @@
 {
   "properties": {
+    "custom_status_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "encoded_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "fields": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {}
+    },
+    "from_messaging_channel": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "support_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "organization_id": {
       "type": [
         "null",

--- a/tap_zendesk/schemas/users.json
+++ b/tap_zendesk/schemas/users.json
@@ -4,6 +4,38 @@
     "object"
   ],
   "properties": {
+    "iana_time_zone": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "is_billing_admin": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "suspension_details": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "channels": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
+    },
     "verified": {
       "type": [
         "null",

--- a/test/test_all_fields.py
+++ b/test/test_all_fields.py
@@ -71,13 +71,23 @@ class ZendeskAllFields(ZendeskTest):
 
                 # As we can't generate following fields by zendesk APIs now so expected.
                 if stream == "ticket_fields":
-                    expected_all_keys = expected_all_keys - {'system_field_options', 'sub_type_id'}
-                elif stream == "users":  # field appeared in syncd records Nov 1 - Dec 18, 2023
-                    expected_all_keys = expected_all_keys - {'chat_only'}
+                    expected_all_keys = expected_all_keys - {
+                        'system_field_options', 'sub_type_id', 'creator_user_id',
+                        'creator_app_name', 'max_selections'
+                    }
+                elif stream == "users":  # field appeared in synced records Nov 1 - Dec 18, 2023
+                    expected_all_keys = expected_all_keys - {'chat_only', 'suspension_details'}
                 elif stream == "ticket_metrics":
-                    expected_all_keys = expected_all_keys - {'status', 'instance_id', 'metric', 'type', 'time'}
+                    expected_all_keys = expected_all_keys - {
+                        'status', 'instance_id', 'metric', 'type', 'time',
+                        'custom_status_updated_at', 'reply_time_in_seconds'
+                    }
                 elif stream == "talk_phone_numbers":
                     expected_all_keys = expected_all_keys - {'token'}
+                elif stream == "support_requests":
+                    expected_all_keys = expected_all_keys - {'solved', 'group_id', 'custom_status_id'}
+                elif stream == "tickets":
+                    expected_all_keys = expected_all_keys - {'custom_status_id'}
 
                 # verify all fields for each stream are replicated
                 self.assertSetEqual(expected_all_keys, actual_all_keys)

--- a/test/test_all_fields.py
+++ b/test/test_all_fields.py
@@ -87,7 +87,7 @@ class ZendeskAllFields(ZendeskTest):
                 elif stream == "support_requests":
                     expected_all_keys = expected_all_keys - {'solved', 'group_id', 'custom_status_id'}
                 elif stream == "tickets":
-                    expected_all_keys = expected_all_keys - {'custom_status_id'}
+                    expected_all_keys = expected_all_keys - {'custom_status_id', 'fields'}
 
                 # verify all fields for each stream are replicated
                 self.assertSetEqual(expected_all_keys, actual_all_keys)

--- a/test/test_lookup_fields.py
+++ b/test/test_lookup_fields.py
@@ -47,6 +47,7 @@ class ZendeskAllFields(ZendeskTest):
             fields_from_field_level_md += lookup_fields_map[stream_name]
             if stream_name == "users":  # field appeared in syncd records Nov 1 - Dec 18, 2023
                 fields_from_field_level_md.remove("chat_only")
+                fields_from_field_level_md.remove("suspension_details")
             stream_to_all_catalog_fields[stream_name] = set(fields_from_field_level_md)
 
         self.run_and_verify_sync(conn_id)


### PR DESCRIPTION
# Description of change
This PR updates the tap’s Singer JSON schemas to include several newly observed Zendesk API fields so they appear in discovery/catalogs and can be replicated downstream. [SAC-32093](https://qlik-dev.atlassian.net/browse/SAC-32093)

Changes:
Add missing schema fields for users, groups, tickets, ticket_fields, ticket_forms, and ticket_metrics.
Introduce new nested structures (e.g., ticket form condition arrays, ticket metric sub-objects) to better reflect API payloads.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
